### PR TITLE
Fixed fetching single secret bug; updated the name variable name in README to be correct.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ vars:
   read_all_secrets_within_scope: "{{ lookup('infisical.vault.read_secrets', token='<>', path='/', env_slug='dev', url='https://spotify.infisical.com') }}"
   # [{ "key": "HOST", "value": "google.com" }, { "key": "SMTP", "value": "gmail.smtp.edu" }]
 
-  read_secret_by_name_within_scope: "{{ lookup('infisical.vault.read_secrets', token='<>', path='/', env_slug='dev', name='HOST', url='https://spotify.infisical.com') }}"
+  read_secret_by_name_within_scope: "{{ lookup('infisical.vault.read_secrets', token='<>', path='/', env_slug='dev', secret_name='HOST', url='https://spotify.infisical.com') }}"
   # [{ "key": "HOST", "value": "google.com" }]
 ```
 

--- a/plugins/lookup/read_secrets.py
+++ b/plugins/lookup/read_secrets.py
@@ -56,7 +56,7 @@ vars:
   read_all_secrets_within_scope: "{{ lookup('infisical_vault', token='<>', path='/', env_slug='dev', url='https://spotify.infisical.com') }}"
   # [{ "key": "HOST", "value": "google.com" }, { "key": "SMTP", "value": "gmail.smtp.edu" }]
 
-  read_secret_by_name_within_scope: "{{ lookup('infisical_vault', token='<>', path='/', env_slug='dev', name='HOST', url='https://spotify.infisical.com') }}"
+  read_secret_by_name_within_scope: "{{ lookup('infisical_vault', token='<>', path='/', env_slug='dev', secret_name='HOST', url='https://spotify.infisical.com') }}"
   # [{ "key": "HOST", "value": "google.com" }]
 """
 
@@ -87,12 +87,11 @@ class LookupModule(LookupBase):
 
     def get_single_secret(self, client, secret_name, environment, path):
         try:
-            print(secret_name, environment, path)
             secret = client.get_secret(secret_name=secret_name, environment=environment, path=path)
-            return [{"value": s.secret_value, "key": s.secret_name}]
+            return [{"value": secret.secret_value, "key": secret.secret_name}]
         except Exception as e:
             print(e)
-            raise AnsibleError(f"Error fetching all secrets {e}")
+            raise AnsibleError(f"Error fetching single secret {e}")
 
     def get_all_secrets(self, client, environment="dev", path="/"):
         try:


### PR DESCRIPTION
This pull request includes changes to the Python script and an updated README.md file.

In the current behavior of this repository, when attempting to fetch a single secret by name, it doesn't work as expected. For example, using `name="HOST" `as specified in README.md will return all values. The correct approach is to use `secret_name="HOST"`. However, this also doesn't work due to a mistake in the `get_single_secret` function.

Additionally, an unnecessary print statement in the `get_single_secret` function has been removed.