### PR TITLE
feat: add token authentication method

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can either call modules by their Fully Qualified Collection Name (FQCN), suc
 
 ### Authentication
 
-The Infisical Ansible Collection supports Universal Auth and OIDC for authenticating against Infisical.
+The Infisical Ansible Collection supports Universal Auth, OIDC, and Token Auth for authenticating against Infisical.
 
 #### Universal Auth
 Using Universal Auth for authentication is the most straight-forward way to get started with using the Ansible collection. 
@@ -53,7 +53,7 @@ You can also provide the `auth_method`, `universal_auth_client_id`, and `univers
 #### OIDC Auth
 To use OIDC Auth, you'll need to provide the ID of your machine identity, and the OIDC JWT to be used for authentication.
 
-Please note that in order to use OIDC Auth, you must have `1.0.10` or newer of the `infisicalsdk` package installed.
+> **Note:** Please note that in order to use OIDC Auth, you must have `1.0.10` or newer of the `infisicalsdk` package installed.
 
 ```yaml
 lookup('infisical.vault.read_secrets', auth_method="oidc-auth" identity_id='<identity-id>', jwt='<oidc-jwt>' ...rest)
@@ -65,6 +65,23 @@ You can also provide the `auth_method`, `identity_id`, and `jwt` parameters thro
 | auth_method     | `INFISICAL_AUTH_METHOD`   |
 | identity_id     | `INFISICAL_IDENTITY_ID`   |
 | jwt             | `INFISICAL_JWT`           |
+
+
+#### Token Auth
+Token Auth is the simplest authentication method that allows you to authenticate directly with an access token. This can be either a [Machine Identity Token Auth](https://infisical.com/docs/documentation/platform/identities/token-auth) token or a User JWT token.
+
+> **Note:** Please note that in order to use Token Auth, you must have `1.0.13` or newer of the `infisicalsdk` package installed.
+
+```yaml
+lookup('infisical.vault.read_secrets', auth_method="token_auth", token='<your-token>' ...rest)
+```
+
+You can also provide the `auth_method` and `token` parameters through environment variables:
+
+| Parameter Name | Environment Variable Name |
+| -------------- | ------------------------- |
+| auth_method    | `INFISICAL_AUTH_METHOD`   |
+| token          | `INFISICAL_TOKEN`         |
 
 
 ### Examples

--- a/plugins/lookup/read_secrets.py
+++ b/plugins/lookup/read_secrets.py
@@ -46,6 +46,7 @@ options:
     choices:
       - universal_auth
       - oidc_auth
+      - token_auth
     env:
       - name: INFISICAL_AUTH_METHOD
   universal_auth_client_id:
@@ -112,6 +113,16 @@ options:
     env:
       - name: INFISICAL_JWT
       - name: INFISICAL_OIDC_AUTH_JWT
+  token:
+    description: >
+      An access token used to authenticate with Infisical. This can be either a Machine Identity Token Auth token
+      or a User JWT token. Both token types can be used interchangeably with this field.
+    required: False
+    type: string
+    version_added: 1.1.4
+    env:
+      - name: INFISICAL_TOKEN
+      - name: INFISICAL_AUTH_TOKEN
 """
 
 EXAMPLES = r"""
@@ -187,8 +198,18 @@ class LookupModule(LookupBase):
             identity_id,
             jwt
         )
+
+      elif method == "token_auth":
+
+        token = self.get_option("token")
+
+        if not token:
+            raise AnsibleError("token is not set. Please provide a valid Machine Identity Token Auth token or User JWT to use token_auth.")
+
+        client.auth.token_auth.login(token)
+
       else:
-        raise AnsibleError(f"Invalid auth method. Please use universal_auth or oidc_auth. You provided {method}")
+        raise AnsibleError(f"Invalid auth method. Please use universal_auth, oidc_auth, or token_auth. You provided {method}")
 
       return client
 

--- a/plugins/lookup/read_secrets.py
+++ b/plugins/lookup/read_secrets.py
@@ -4,6 +4,10 @@ from ansible.plugins.lookup import LookupBase
 HAS_INFISICAL = False
 INFISICAL_VERSION = None
 
+# Authentication Methods
+AUTH_METHOD_UNIVERSAL_AUTH = "universal_auth"
+AUTH_METHOD_OIDC_AUTH = "oidc_auth"
+AUTH_METHOD_TOKEN_AUTH = "token_auth"
 
 try:
     from infisical_sdk import InfisicalSDKClient
@@ -122,7 +126,6 @@ options:
     version_added: 1.1.4
     env:
       - name: INFISICAL_TOKEN
-      - name: INFISICAL_AUTH_TOKEN
 """
 
 EXAMPLES = r"""
@@ -169,7 +172,7 @@ class LookupModule(LookupBase):
 
       method = self.get_option("auth_method")
 
-      if method == "universal_auth":
+      if method == AUTH_METHOD_UNIVERSAL_AUTH:
 
         machine_identity_client_id = self.get_option("universal_auth_client_id")
         machine_identity_client_secret = self.get_option("universal_auth_client_secret")
@@ -182,7 +185,7 @@ class LookupModule(LookupBase):
             machine_identity_client_secret
         )
 
-      elif method == "oidc_auth":
+      elif method == AUTH_METHOD_OIDC_AUTH:
 
         # make sure the infisicalsdk version is at least 1.0.10
         if not check_minimum_version(INFISICAL_VERSION, "1.0.10"):
@@ -199,7 +202,7 @@ class LookupModule(LookupBase):
             jwt
         )
 
-      elif method == "token_auth":
+      elif method == AUTH_METHOD_TOKEN_AUTH:
 
         token = self.get_option("token")
 


### PR DESCRIPTION
This PR adds [token auth](https://infisical.com/docs/documentation/platform/identities/token-auth#token-auth) support for Ansible.

This is valid for machine identity tokens and user tokens.

You can test it with docker using the commands:

```
docker run -it --rm \
  -v "$(pwd)":/workspace \
  -e INFISICAL_TOKEN="your-token" \
  -e INFISICAL_URL="http://host.docker.internal:8080" \
  python:3.11-slim \
  /bin/bash -c "
    pip install ansible infisicalsdk && \
    cd /workspace && \
    ansible-galaxy collection build . --output-path /tmp/ && \
    ansible-galaxy collection install /tmp/infisical-vault-*.tar.gz --force && \
    /bin/bash
  "
```
  
And then
  
`ansible localhost -m debug -a "msg={{ lookup('infisical.vault.read_secrets', auth_method='token_auth', project_id='YOUR_PROJECT_ID', path='/', env_slug='dev') }}"`

or create a test playbook inside the container:

```
cat > /tmp/test.yml << 'EOF'
---
- name: Test Token Auth
  hosts: localhost
  connection: local
  gather_facts: false
  
  tasks:
    - name: Fetch secrets using token_auth
      ansible.builtin.debug:
        msg: "{{ lookup('infisical.vault.read_secrets',
                        auth_method='token_auth',
                        project_id='YOUR_PROJECT_ID',
                        path='/',
                        env_slug='dev') }}"
EOF
```

and run it

`ansible-playbook /tmp/test.yml -v`