### PR TITLE
feature(secrets): added login and modules for secrets crud operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ The Infisical Ansible Collection supports Universal Auth, OIDC, and Token Auth f
 The recommended approach is to use the `login` lookup or module to authenticate once and reuse the credentials across multiple tasks. This reduces authentication overhead and makes playbooks cleaner.
 You can also provide the authentication details directly on the plugins.
 
+**Using the login module:**
+
 ```yaml
 - name: Login to Infisical
   infisical.vault.login:
@@ -62,6 +64,27 @@ You can also provide the authentication details directly on the plugins.
 - name: Use the secrets
   debug:
     msg: "Database URL is {{ secrets.secrets.DATABASE_URL }}"
+```
+
+**Using inline credentials:**
+
+```yaml
+- name: Read secrets with inline credentials
+  set_fact:
+    secrets: "{{ lookup('infisical.vault.read_secrets',
+      url='https://app.infisical.com',
+      auth_method='universal_auth',
+      universal_auth_client_id=client_id,
+      universal_auth_client_secret=client_secret,
+      project_id=project_id,
+      env_slug='dev',
+      path='/',
+      as_dict=true
+    ) }}"
+
+- name: Use the secrets
+  debug:
+    msg: "Database URL is {{ secrets.DATABASE_URL }}"
 ```
 
 ### Universal Auth

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Infisical Collection
+
 This Ansible Infisical collection includes a variety of Ansible content to help automate the management of Infisical services. This collection is maintained by the Infisical team.
 
-[View full documentation](https://galaxy.ansible.com/ui/repo/published/infisical/vault/)
+[View full documentation](https://infisical.com/docs/integrations/platforms/ansible)
 
 ## Ansible version compatibility
 
@@ -17,31 +18,57 @@ Requires Python 3.7 or greater.
 
 You can install the Infisical collection with the Ansible Galaxy CLI:
 
-    ansible-galaxy collection install infisical.vault
+```bash
+ansible-galaxy collection install infisical.vault
+```
 
-The python module dependencies are not installed by `ansible-galaxy`.  They can
-be manually installed using pip:
+The python module dependencies are not installed by `ansible-galaxy`. They can be manually installed using pip:
 
-    pip install infisicalsdk
+```bash
+pip install infisicalsdk
+```
 
 ## Using this collection
 
 You can either call modules by their Fully Qualified Collection Name (FQCN), such as `infisical.vault.read_secrets`, or you can call modules by their short name if you list the `infisical.vault` collection in the playbook's `collections` keyword.
 
-### Authentication
+## Authentication
 
 The Infisical Ansible Collection supports Universal Auth, OIDC, and Token Auth for authenticating against Infisical.
 
-#### Universal Auth
-Using Universal Auth for authentication is the most straight-forward way to get started with using the Ansible collection. 
+### Login Plugin (Recommended)
 
-To use Universal Auth, you need to provide the Client ID and Client Secret of your Infisical Machine Identity.
+The recommended approach is to use the `login` lookup or module to authenticate once and reuse the credentials across multiple tasks. This reduces authentication overhead and makes playbooks cleaner.
+You can also provide the authnetication details directly on the plugins.
 
 ```yaml
-lookup('infisical.vault.read_secrets', auth_method="universal-auth" universal_auth_client_id='<client-id>', universal_auth_client_secret='<client-secret>' ...rest)
+- name: Login to Infisical
+  infisical.vault.login:
+    url: "https://app.infisical.com"
+    auth_method: universal_auth
+    universal_auth_client_id: "{{ client_id }}"
+    universal_auth_client_secret: "{{ client_secret }}"
+  register: infisical_login
+
+- name: Read secrets using cached login
+  infisical.vault.read_secrets:
+    login_data: "{{ infisical_login.login_data }}"
+    project_id: "{{ project_id }}"
+    env_slug: "dev"
+    path: "/"
+    as_dict: true
+  register: secrets
+
+- name: Use the secrets
+  debug:
+    msg: "Database URL is {{ secrets.secrets.DATABASE_URL }}"
 ```
 
-You can also provide the `auth_method`, `universal_auth_client_id`, and `universal_auth_client_secret` parameters through environment variables:
+### Universal Auth
+
+Using Universal Auth for authentication is the most straight-forward way to get started. You need to provide the Client ID and Client Secret of your Infisical Machine Identity.
+
+You can provide the parameters through environment variables:
 
 | Parameter Name               | Environment Variable Name                |
 | ---------------------------- | ---------------------------------------- |
@@ -49,16 +76,11 @@ You can also provide the `auth_method`, `universal_auth_client_id`, and `univers
 | universal_auth_client_id     | `INFISICAL_UNIVERSAL_AUTH_CLIENT_ID`     |
 | universal_auth_client_secret | `INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET` |
 
+### OIDC Auth
 
-#### OIDC Auth
-To use OIDC Auth, you'll need to provide the ID of your machine identity, and the OIDC JWT to be used for authentication.
+To use OIDC Auth, you'll need to provide the ID of your machine identity and the OIDC JWT for authentication.
 
-> **Note:** Please note that in order to use OIDC Auth, you must have `1.0.10` or newer of the `infisicalsdk` package installed.
-
-```yaml
-lookup('infisical.vault.read_secrets', auth_method="oidc-auth" identity_id='<identity-id>', jwt='<oidc-jwt>' ...rest)
-```
-You can also provide the `auth_method`, `identity_id`, and `jwt` parameters through environment variables:
+> **Note:** OIDC Auth requires `infisicalsdk` version 1.0.10 or newer.
 
 | Parameter Name  | Environment Variable Name |
 | --------------- | ------------------------- |
@@ -66,36 +88,89 @@ You can also provide the `auth_method`, `identity_id`, and `jwt` parameters thro
 | identity_id     | `INFISICAL_IDENTITY_ID`   |
 | jwt             | `INFISICAL_JWT`           |
 
+### Token Auth
 
-#### Token Auth
-Token Auth is the simplest authentication method that allows you to authenticate directly with an access token. This can be either a [Machine Identity Token Auth](https://infisical.com/docs/documentation/platform/identities/token-auth) token or a User JWT token.
+Token Auth allows you to authenticate directly with an access token. This can be either a [Machine Identity Token Auth](https://infisical.com/docs/documentation/platform/identities/token-auth) token or a User JWT token.
 
-> **Note:** Please note that in order to use Token Auth, you must have `1.0.13` or newer of the `infisicalsdk` package installed.
-
-```yaml
-lookup('infisical.vault.read_secrets', auth_method="token_auth", token='<your-token>' ...rest)
-```
-
-You can also provide the `auth_method` and `token` parameters through environment variables:
+> **Note:** Token Auth requires `infisicalsdk` version 1.0.13 or newer.
 
 | Parameter Name | Environment Variable Name |
 | -------------- | ------------------------- |
 | auth_method    | `INFISICAL_AUTH_METHOD`   |
 | token          | `INFISICAL_TOKEN`         |
 
+## Available Plugins and Modules
 
-### Examples
+### Lookups
+- `infisical.vault.login` - Authenticate and return reusable login data
+- `infisical.vault.read_secrets` - Read secrets from Infisical
+
+### Modules
+- `infisical.vault.login` - Authenticate and return reusable login data
+- `infisical.vault.read_secrets` - Read secrets from Infisical
+- `infisical.vault.create_secret` - Create a new secret
+- `infisical.vault.update_secret` - Update an existing secret
+- `infisical.vault.delete_secret` - Delete a secret
+
+## Examples
+
+### Reading Secrets
 
 ```yaml
 ---
-vars:
-  read_all_secrets_within_scope: "{{ lookup('infisical.vault.read_secrets', universal_auth_client_id='<>', universal_auth_client_secret='<>', project_id='<>', path='/', env_slug='dev', url='https://spotify.infisical.com') }}"
-  # [{ "key": "HOST", "value": "google.com" }, { "key": "SMTP", "value": "gmail.smtp.edu" }]
+- name: Read secrets from Infisical
+  hosts: localhost
+  gather_facts: false
 
-   read_all_secrets_as_dict: "{{ lookup('infisical.vault.read_secrets', universal_auth_client_id='<>', universal_auth_client_secret='<>', project_id='<>', path='/', env_slug='dev', as_dict=True, url='https://spotify.infisical.com') }}"
-  # {"SECRET_KEY_1": "secret-value-1", "SECRET_KEY_2": "secret-value-2"} -> Can be accessed as secrets.SECRET_KEY_1
+  tasks:
+    - name: Login to Infisical
+      infisical.vault.login:
+        url: "https://app.infisical.com"
+        auth_method: universal_auth
+        universal_auth_client_id: "{{ lookup('env', 'INFISICAL_CLIENT_ID') }}"
+        universal_auth_client_secret: "{{ lookup('env', 'INFISICAL_CLIENT_SECRET') }}"
+      register: infisical_login
 
-  read_secret_by_name_within_scope: "{{ lookup('infisical.vault.read_secrets', universal_auth_client_id='<>', universal_auth_client_secret='<>', project_id='<>', path='/', env_slug='dev', secret_name='HOST', url='https://spotify.infisical.com') }}"
-  # { "key": "HOST", "value": "google.com" }
+    - name: Read all secrets as dictionary
+      infisical.vault.read_secrets:
+        login_data: "{{ infisical_login.login_data }}"
+        project_id: "your-project-id"
+        env_slug: "dev"
+        path: "/"
+        as_dict: true
+      register: secrets
+
+    - name: Use the secrets
+      debug:
+        msg: "Database: {{ secrets.secrets.DATABASE_URL }}"
 ```
 
+### Managing Secrets (CRUD)
+
+```yaml
+- name: Create a secret
+  infisical.vault.create_secret:
+    login_data: "{{ infisical_login.login_data }}"
+    project_id: "{{ project_id }}"
+    env_slug: "dev"
+    path: "/"
+    secret_name: "API_KEY"
+    secret_value: "my-api-key"
+
+- name: Update a secret
+  infisical.vault.update_secret:
+    login_data: "{{ infisical_login.login_data }}"
+    project_id: "{{ project_id }}"
+    env_slug: "dev"
+    path: "/"
+    secret_name: "API_KEY"
+    secret_value: "new-api-key"
+
+- name: Delete a secret
+  infisical.vault.delete_secret:
+    login_data: "{{ infisical_login.login_data }}"
+    project_id: "{{ project_id }}"
+    env_slug: "dev"
+    path: "/"
+    secret_name: "API_KEY"
+```

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The Infisical Ansible Collection supports Universal Auth, OIDC, and Token Auth f
 ### Login Plugin (Recommended)
 
 The recommended approach is to use the `login` lookup or module to authenticate once and reuse the credentials across multiple tasks. This reduces authentication overhead and makes playbooks cleaner.
-You can also provide the authnetication details directly on the plugins.
+You can also provide the authentication details directly on the plugins.
 
 ```yaml
 - name: Login to Infisical

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -50,7 +50,7 @@ dependencies: {}
 repository: https://github.com/Infisical/ansible-collection
 
 # The URL to any online docs
-documentation: http://docs.example.com
+documentation: https://infisical.com/docs/integrations/platforms/ansible
 
 # The URL to the homepage of the collection/project
 homepage: https://infisical.com

--- a/plugins/doc_fragments/auth.py
+++ b/plugins/doc_fragments/auth.py
@@ -5,14 +5,14 @@ __metaclass__ = type
 # Shared option definitions
 _URL_MODULE = """
   url:
-    description: Point to your self hosted instance of Infisical.
+    description: Point to your self-hosted instance of Infisical.
     type: str
     default: "https://app.infisical.com"
 """
 
 _URL_LOOKUP = """
   url:
-    description: Point to your self hosted instance of Infisical.
+    description: Point to your self-hosted instance of Infisical.
     default: "https://app.infisical.com"
     env:
       - name: INFISICAL_URL

--- a/plugins/doc_fragments/auth.py
+++ b/plugins/doc_fragments/auth.py
@@ -1,0 +1,201 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+# Shared option definitions
+_URL_MODULE = """
+  url:
+    description: Point to your self hosted instance of Infisical.
+    type: str
+    default: "https://app.infisical.com"
+"""
+
+_URL_LOOKUP = """
+  url:
+    description: Point to your self hosted instance of Infisical.
+    default: "https://app.infisical.com"
+    env:
+      - name: INFISICAL_URL
+    required: False
+    type: string
+"""
+
+_AUTH_METHOD_MODULE = """
+  auth_method:
+    description: The method to use to authenticate with Infisical.
+    type: str
+    default: universal_auth
+    choices:
+      - universal_auth
+      - oidc_auth
+      - token_auth
+"""
+
+_AUTH_METHOD_LOOKUP = """
+  auth_method:
+    description: The method to use to authenticate with Infisical.
+    required: False
+    type: string
+    default: universal_auth
+    choices:
+      - universal_auth
+      - oidc_auth
+      - token_auth
+    env:
+      - name: INFISICAL_AUTH_METHOD
+"""
+
+_UNIVERSAL_AUTH_MODULE = """
+  universal_auth_client_id:
+    description: The Machine Identity Client ID used to authenticate (for universal_auth).
+    type: str
+  universal_auth_client_secret:
+    description: The Machine Identity Client Secret used to authenticate (for universal_auth).
+    type: str
+    no_log: true
+"""
+
+_UNIVERSAL_AUTH_LOOKUP = """
+  universal_auth_client_id:
+    description: The Machine Identity Client ID used to authenticate.
+    env:
+      - name: UNIVERSAL_AUTH_MACHINE_IDENTITY_CLIENT_ID
+      - name: INFISICAL_UNIVERSAL_AUTH_CLIENT_ID
+    required: False
+    type: string
+  universal_auth_client_secret:
+    description: The Machine Identity Client Secret used to authenticate.
+    env:
+      - name: UNIVERSAL_AUTH_MACHINE_IDENTITY_CLIENT_SECRET
+      - name: INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET
+    required: False
+    type: string
+"""
+
+_OIDC_AUTH_MODULE = """
+  identity_id:
+    description: The identity ID of the user that should be authenticated (for OIDC auth).
+    type: str
+  jwt:
+    description: The JWT of the user that should be authenticated (for OIDC auth).
+    type: str
+    no_log: true
+"""
+
+_OIDC_AUTH_LOOKUP = """
+  identity_id:
+    description: The identity ID of the user that should be authenticated (for OIDC auth).
+    env:
+      - name: INFISICAL_MACHINE_IDENTITY_ID
+    required: False
+    type: string
+  jwt:
+    description: The JWT of the user that should be authenticated (for OIDC auth).
+    required: False
+    type: string
+    env:
+      - name: INFISICAL_JWT
+      - name: INFISICAL_OIDC_AUTH_JWT
+"""
+
+_TOKEN_AUTH_MODULE = """
+  token:
+    description: >
+      An access token used to authenticate with Infisical. This can be either a Machine Identity Token Auth token
+      or a User JWT token. Both token types can be used interchangeably with this field.
+    type: str
+    no_log: true
+"""
+
+_TOKEN_AUTH_LOOKUP = """
+  token:
+    description: >
+      An access token used to authenticate with Infisical. This can be either a Machine Identity Token Auth token
+      or a User JWT token. Both token types can be used interchangeably with this field.
+    required: False
+    type: string
+    env:
+      - name: INFISICAL_TOKEN
+"""
+
+_LOGIN_DATA_MODULE = """
+  login_data:
+    description:
+      - Login data from a previous C(infisical.vault.login) operation.
+      - When provided, the access token from the login data will be used, avoiding re-authentication.
+      - This should be a dictionary containing C(url) and C(access_token) keys.
+    type: dict
+"""
+
+_LOGIN_DATA_LOOKUP = """
+  login_data:
+    description:
+      - Login data from a previous C(infisical.vault.login) lookup.
+      - When provided, the access token from the login data will be used, avoiding re-authentication.
+      - This is mutually exclusive with direct authentication options (auth_method, universal_auth_client_id, etc.).
+    required: False
+    type: dict
+"""
+
+_LOGIN_DATA_NOTE = """
+notes:
+  - When using C(login_data), the C(url), C(auth_method), and authentication credential parameters are ignored.
+"""
+
+
+class ModuleDocFragment:
+    """Documentation fragment for Infisical authentication options."""
+
+    # Authentication options for login module (no login_data option)
+    LOGIN = r"""
+options:
+{url}{auth_method}{universal_auth}{oidc_auth}{token_auth}
+""".format(
+        url=_URL_MODULE,
+        auth_method=_AUTH_METHOD_MODULE,
+        universal_auth=_UNIVERSAL_AUTH_MODULE,
+        oidc_auth=_OIDC_AUTH_MODULE,
+        token_auth=_TOKEN_AUTH_MODULE,
+    )
+
+    # Standard authentication options for modules (includes login_data)
+    DOCUMENTATION = r"""
+options:
+{login_data}{url}{auth_method}{universal_auth}{oidc_auth}{token_auth}
+{note}
+""".format(
+        login_data=_LOGIN_DATA_MODULE,
+        url=_URL_MODULE,
+        auth_method=_AUTH_METHOD_MODULE,
+        universal_auth=_UNIVERSAL_AUTH_MODULE,
+        oidc_auth=_OIDC_AUTH_MODULE,
+        token_auth=_TOKEN_AUTH_MODULE,
+        note=_LOGIN_DATA_NOTE,
+    )
+
+    # Authentication options for lookup plugins (with env vars, includes login_data)
+    LOOKUP = r"""
+options:
+{login_data}{url}{auth_method}{universal_auth}{oidc_auth}{token_auth}
+{note}
+""".format(
+        login_data=_LOGIN_DATA_LOOKUP,
+        url=_URL_LOOKUP,
+        auth_method=_AUTH_METHOD_LOOKUP,
+        universal_auth=_UNIVERSAL_AUTH_LOOKUP,
+        oidc_auth=_OIDC_AUTH_LOOKUP,
+        token_auth=_TOKEN_AUTH_LOOKUP,
+        note=_LOGIN_DATA_NOTE,
+    )
+
+    # Authentication options for login lookup (no login_data, with env vars)
+    LOOKUP_LOGIN = r"""
+options:
+{url}{auth_method}{universal_auth}{oidc_auth}{token_auth}
+""".format(
+        url=_URL_LOOKUP,
+        auth_method=_AUTH_METHOD_LOOKUP,
+        universal_auth=_UNIVERSAL_AUTH_LOOKUP,
+        oidc_auth=_OIDC_AUTH_LOOKUP,
+        token_auth=_TOKEN_AUTH_LOOKUP,
+    )

--- a/plugins/lookup/login.py
+++ b/plugins/lookup/login.py
@@ -1,0 +1,140 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible.errors import AnsibleError
+from ansible.plugins.lookup import LookupBase
+
+from ansible_collections.infisical.vault.plugins.module_utils._authenticator import (
+    InfisicalAuthenticator,
+)
+
+
+DOCUMENTATION = r"""
+name: login
+author:
+  - Infisical Inc.
+version_added: "1.2.0"
+
+short_description: Perform a login operation against Infisical
+description:
+  - Performs a login operation against Infisical, returning an authenticated SDK client.
+  - The client can be cached and reused across multiple subsequent lookups to avoid repeated authentication.
+  - This is useful for playbooks that need to fetch multiple secrets, as it reduces the number of authentication requests.
+
+seealso:
+  - ref: infisical.vault.read_secrets lookup
+    description: Use the client with read_secrets to fetch secrets without re-authenticating.
+
+notes:
+  - This lookup does not use the term string and will not work correctly in loops. Only a single response will be returned.
+
+options:
+  auth_method:
+    description: The method to use to authenticate with Infisical
+    required: False
+    type: string
+    default: universal_auth
+    choices:
+      - universal_auth
+      - oidc_auth
+      - token_auth
+    env:
+      - name: INFISICAL_AUTH_METHOD
+  universal_auth_client_id:
+    description: The Machine Identity Client ID used to authenticate
+    env:
+      - name: UNIVERSAL_AUTH_MACHINE_IDENTITY_CLIENT_ID
+      - name: INFISICAL_UNIVERSAL_AUTH_CLIENT_ID
+    required: False
+    type: string
+  universal_auth_client_secret:
+    description: The Machine Identity Client Secret used to authenticate
+    env:
+      - name: UNIVERSAL_AUTH_MACHINE_IDENTITY_CLIENT_SECRET
+      - name: INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET
+    required: False
+    type: string
+  url:
+    description: Point to your self hosted instance of Infisical
+    default: "https://app.infisical.com"
+    env:
+      - name: INFISICAL_URL
+    required: False
+    type: string
+  identity_id:
+    description: The identity ID of the user that should be authenticated (for OIDC auth)
+    env:
+      - name: INFISICAL_MACHINE_IDENTITY_ID
+    required: False
+    type: string
+  jwt:
+    description: The JWT of the user that should be authenticated (for OIDC auth)
+    required: False
+    type: string
+    env:
+      - name: INFISICAL_JWT
+      - name: INFISICAL_OIDC_AUTH_JWT
+  token:
+    description: >
+      An access token used to authenticate with Infisical. This can be either a Machine Identity Token Auth token
+      or a User JWT token. Both token types can be used interchangeably with this field.
+    required: False
+    type: string
+    env:
+      - name: INFISICAL_TOKEN
+"""
+
+EXAMPLES = r"""
+# Login once and reuse the client for multiple secret lookups
+- name: Login to Infisical
+  set_fact:
+    infisical_client: "{{ lookup('infisical.vault.login', url='https://app.infisical.com', auth_method='universal_auth', universal_auth_client_id='<client-id>', universal_auth_client_secret='<client-secret>') }}"
+
+- name: Read secrets using the cached client
+  set_fact:
+    db_secrets: "{{ lookup('infisical.vault.read_secrets', client=infisical_client, project_id='<project-id>', path='/database', env_slug='prod') }}"
+
+- name: Read more secrets using the same client (no re-authentication)
+  set_fact:
+    api_secrets: "{{ lookup('infisical.vault.read_secrets', client=infisical_client, project_id='<project-id>', path='/api', env_slug='prod') }}"
+
+# Using OIDC authentication
+- name: Login with OIDC
+  set_fact:
+    infisical_client: "{{ lookup('infisical.vault.login', auth_method='oidc_auth', identity_id='<identity-id>', jwt='<jwt-token>') }}"
+
+# Using token authentication
+- name: Login with token
+  set_fact:
+    infisical_client: "{{ lookup('infisical.vault.login', auth_method='token_auth', token='<your-token>') }}"
+"""
+
+RETURN = r"""
+_raw:
+  description:
+    - The authenticated Infisical SDK client instance.
+    - This client can be passed to other lookups via the C(client) parameter to avoid re-authentication.
+  type: list
+  elements: object
+"""
+
+
+class LookupModule(LookupBase):
+
+    def run(self, terms, variables=None, **kwargs):
+        self.set_options(var_options=variables, direct=kwargs)
+
+        authenticator = InfisicalAuthenticator(
+            url=self.get_option('url'),
+            auth_method=self.get_option('auth_method'),
+            client_id=self.get_option('universal_auth_client_id'),
+            client_secret=self.get_option('universal_auth_client_secret'),
+            identity_id=self.get_option('identity_id'),
+            jwt=self.get_option('jwt'),
+            token=self.get_option('token'),
+        )
+        
+        try:
+            return [authenticator.authenticate()]
+        except (ImportError, ValueError) as e:
+            raise AnsibleError(str(e))

--- a/plugins/lookup/login.py
+++ b/plugins/lookup/login.py
@@ -20,6 +20,8 @@ description:
   - Performs a login operation against Infisical, returning login data containing an access token.
   - The login data can be cached and reused across multiple subsequent lookups to avoid repeated authentication.
   - This is useful for playbooks that need to fetch multiple secrets, as it reduces the number of authentication requests.
+extends_documentation_fragment:
+  - infisical.vault.auth.lookup_login
 
 seealso:
   - ref: infisical.vault.read_secrets lookup
@@ -28,61 +30,6 @@ seealso:
 notes:
   - This lookup does not use the term string and will not work correctly in loops. Only a single response will be returned.
   - The returned login_data contains the access token and can be stored in an Ansible variable for reuse.
-
-options:
-  auth_method:
-    description: The method to use to authenticate with Infisical
-    required: False
-    type: string
-    default: universal_auth
-    choices:
-      - universal_auth
-      - oidc_auth
-      - token_auth
-    env:
-      - name: INFISICAL_AUTH_METHOD
-  universal_auth_client_id:
-    description: The Machine Identity Client ID used to authenticate
-    env:
-      - name: UNIVERSAL_AUTH_MACHINE_IDENTITY_CLIENT_ID
-      - name: INFISICAL_UNIVERSAL_AUTH_CLIENT_ID
-    required: False
-    type: string
-  universal_auth_client_secret:
-    description: The Machine Identity Client Secret used to authenticate
-    env:
-      - name: UNIVERSAL_AUTH_MACHINE_IDENTITY_CLIENT_SECRET
-      - name: INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET
-    required: False
-    type: string
-  url:
-    description: Point to your self hosted instance of Infisical
-    default: "https://app.infisical.com"
-    env:
-      - name: INFISICAL_URL
-    required: False
-    type: string
-  identity_id:
-    description: The identity ID of the user that should be authenticated (for OIDC auth)
-    env:
-      - name: INFISICAL_MACHINE_IDENTITY_ID
-    required: False
-    type: string
-  jwt:
-    description: The JWT of the user that should be authenticated (for OIDC auth)
-    required: False
-    type: string
-    env:
-      - name: INFISICAL_JWT
-      - name: INFISICAL_OIDC_AUTH_JWT
-  token:
-    description: >
-      An access token used to authenticate with Infisical. This can be either a Machine Identity Token Auth token
-      or a User JWT token. Both token types can be used interchangeably with this field.
-    required: False
-    type: string
-    env:
-      - name: INFISICAL_TOKEN
 """
 
 EXAMPLES = r"""

--- a/plugins/lookup/read_secrets.py
+++ b/plugins/lookup/read_secrets.py
@@ -8,6 +8,9 @@ from ansible_collections.infisical.vault.plugins.module_utils._authenticator imp
     InfisicalAuthenticator,
     create_client_from_login_data,
 )
+from ansible_collections.infisical.vault.plugins.module_utils._secrets import (
+    clean_secret_dict,
+)
 
 
 DOCUMENTATION = r"""
@@ -20,57 +23,14 @@ description:
   - Retrieve secrets from Infisical, granted the caller has the right permissions to access the secret.
   - Secrets can be located either by their name for individual secret lookups or by environment/folder path to return all secrets within the given scope.
   - You can either provide authentication credentials directly, or use C(login_data) from a previous C(infisical.vault.login) lookup to reuse an authenticated session.
+extends_documentation_fragment:
+  - infisical.vault.auth.lookup
 
 seealso:
   - ref: infisical.vault.login lookup
     description: Use the login lookup to authenticate once and reuse the session.
 
 options:
-
-  login_data:
-    description:
-      - Login data from a previous C(infisical.vault.login) lookup.
-      - When provided, the access token from the login data will be used, avoiding re-authentication.
-      - This is mutually exclusive with direct authentication options (auth_method, universal_auth_client_id, etc.).
-    required: False
-    type: dict
-    version_added: 1.2.0
-  auth_method:
-    description: The method to use to authenticate with Infisical
-    required: False
-    type: string
-    version_added: 1.1.3
-    default: universal_auth
-    choices:
-      - universal_auth
-      - oidc_auth
-      - token_auth
-    env:
-      - name: INFISICAL_AUTH_METHOD
-  universal_auth_client_id:
-    description: The Machine Identity Client ID used to authenticate
-    env:
-      - name: UNIVERSAL_AUTH_MACHINE_IDENTITY_CLIENT_ID
-      - name: INFISICAL_UNIVERSAL_AUTH_CLIENT_ID
-    required: False
-    type: string
-    version_added: 1.0.0
-  universal_auth_client_secret:
-    description: The Machine Identity Client Secret used to authenticate
-    env:
-      - name: UNIVERSAL_AUTH_MACHINE_IDENTITY_CLIENT_SECRET
-      - name: INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET
-    required: False
-    type: string
-    version_added: 1.0.0
-  url:
-    description: Point to your self hosted instance of Infisical
-    default: "https://app.infisical.com"
-    env:
-      - name: INFISICAL_URL
-    required: False
-    type: string
-    version_added: 1.0.0
   path:
     description: "The folder path where the requested secret resides. For example: /services/backend"
     required: True
@@ -96,30 +56,15 @@ options:
     required: False
     type: bool
     version_added: 1.0.0
-  identity_id:
-    description: The identity ID of the user that should be authenticated
-    env:
-      - name: INFISICAL_MACHINE_IDENTITY_ID
-    required: False
-    type: string
-    version_added: 1.1.3
-  jwt:
-    description: The JWT of the user that should be authenticated
-    required: False
-    type: string
-    version_added: 1.1.3
-    env:
-      - name: INFISICAL_JWT
-      - name: INFISICAL_OIDC_AUTH_JWT
-  token:
+  raw:
     description: >
-      An access token used to authenticate with Infisical. This can be either a Machine Identity Token Auth token
-      or a User JWT token. Both token types can be used interchangeably with this field.
+      Return the full secret object with all properties instead of just key/value.
+      When True, returns all secret metadata including id, version, type, secretComment, createdAt, updatedAt, tags, etc.
+      When combined with C(as_dict=True), returns a dictionary where keys are secret names and values are full secret objects.
     required: False
-    type: string
-    version_added: 1.1.4
-    env:
-      - name: INFISICAL_TOKEN
+    type: bool
+    default: False
+    version_added: 1.2.0
 """
 
 EXAMPLES = r"""
@@ -151,6 +96,87 @@ vars:
 - name: Read a specific secret using cached login
   set_fact:
     api_key: "{{ lookup('infisical.vault.read_secrets', login_data=infisical_login, project_id='<project-id>', path='/api', env_slug='prod', secret_name='API_KEY') }}"
+
+# Using raw=True to get full secret metadata
+- name: Read all secrets with full metadata
+  set_fact:
+    raw_secrets: "{{ lookup('infisical.vault.read_secrets', login_data=infisical_login, project_id='<project-id>', path='/', env_slug='dev', raw=True) }}"
+  # Returns: [{"id": "...", "secretKey": "HOST", "secretValue": "google.com", "version": 1, "type": "shared", ...}, ...]
+
+- name: Read all secrets with full metadata as dict
+  set_fact:
+    raw_secrets_dict: "{{ lookup('infisical.vault.read_secrets', login_data=infisical_login, project_id='<project-id>', path='/', env_slug='dev', raw=True, as_dict=True) }}"
+  # Returns: {"HOST": {"id": "...", "secretKey": "HOST", "secretValue": "google.com", "version": 1, ...}, ...}
+"""
+
+RETURN = r"""
+_list:
+  description:
+    - When C(raw=False) (default) and C(as_dict=False), returns a list of dictionaries with 'key' and 'value' keys.
+    - When C(raw=False) and C(as_dict=True), returns a list containing a single dictionary mapping secret names to values.
+    - When C(raw=True), returns a list of full secret objects with all properties.
+    - When C(raw=True) and C(as_dict=True), returns a list containing a single dictionary mapping secret names to full secret objects.
+  type: list
+  elements: raw
+  contains:
+    key:
+      description: The name of the secret (when C(raw=False)).
+      type: str
+    value:
+      description: The value of the secret (when C(raw=False)).
+      type: str
+    id:
+      description: The unique identifier of the secret (when C(raw=True)).
+      type: str
+    workspace:
+      description: The workspace/project ID where the secret resides (when C(raw=True)).
+      type: str
+    environment:
+      description: The environment slug (when C(raw=True)).
+      type: str
+    version:
+      description: The version number of the secret (when C(raw=True)).
+      type: int
+    type:
+      description: The type of secret - shared or personal (when C(raw=True)).
+      type: str
+    secretKey:
+      description: The name of the secret (when C(raw=True)).
+      type: str
+    secretValue:
+      description: The value of the secret (when C(raw=True)).
+      type: str
+    secretComment:
+      description: The comment associated with the secret (when C(raw=True)).
+      type: str
+    createdAt:
+      description: The creation timestamp (when C(raw=True)).
+      type: str
+    updatedAt:
+      description: The last update timestamp (when C(raw=True)).
+      type: str
+    secretMetadata:
+      description: Additional metadata for the secret (when C(raw=True)).
+      type: dict
+    secretValueHidden:
+      description: Whether the secret value is hidden (when C(raw=True)).
+      type: bool
+    secretReminderNote:
+      description: A note for the secret reminder (when C(raw=True)).
+      type: str
+    secretReminderRepeatDays:
+      description: Number of days between secret reminder repeats (when C(raw=True)).
+      type: int
+    skipMultilineEncoding:
+      description: Whether multiline encoding was skipped (when C(raw=True)).
+      type: bool
+    secretPath:
+      description: The path where the secret is stored (when C(raw=True)).
+      type: str
+    tags:
+      description: List of tags attached to the secret (when C(raw=True)).
+      type: list
+      elements: dict
 """
 
 
@@ -197,17 +223,18 @@ class LookupModule(LookupBase):
         client = self._get_sdk_client(login_data=login_data)
 
         secret_name = kwargs.get('secret_name')
-        as_dict = kwargs.get('as_dict')
+        as_dict = kwargs.get('as_dict', False)
+        raw = kwargs.get('raw', False)
         env_slug = kwargs.get('env_slug')
         path = kwargs.get('path')
         project_id = kwargs.get('project_id')
 
         if secret_name:
-            return self._get_single_secret(client, project_id, secret_name, env_slug, path)
+            return self._get_single_secret(client, project_id, secret_name, env_slug, path, raw)
         else:
-            return self._get_all_secrets(client, project_id, env_slug, path, as_dict)
+            return self._get_all_secrets(client, project_id, env_slug, path, as_dict, raw)
 
-    def _get_single_secret(self, client, project_id, secret_name, environment, path):
+    def _get_single_secret(self, client, project_id, secret_name, environment, path, raw=False):
         """Fetch a single secret by name."""
         try:
             secret = client.secrets.get_secret_by_name(
@@ -216,11 +243,13 @@ class LookupModule(LookupBase):
                 environment_slug=environment,
                 secret_path=path
             )
+            if raw:
+                return [clean_secret_dict(secret.to_dict())]
             return [{"value": secret.secretValue, "key": secret.secretKey}]
         except Exception as e:
             raise AnsibleError(f"Error fetching secret '{secret_name}': {e}")
 
-    def _get_all_secrets(self, client, project_id, environment="dev", path="/", as_dict=False):
+    def _get_all_secrets(self, client, project_id, environment="dev", path="/", as_dict=False, raw=False):
         """Fetch all secrets within the specified scope."""
         try:
             secrets = client.secrets.list_secrets(
@@ -230,8 +259,12 @@ class LookupModule(LookupBase):
             )
 
             if as_dict:
+                if raw:
+                    return [{s.secretKey: clean_secret_dict(s.to_dict()) for s in secrets.secrets}]
                 return [{s.secretKey: s.secretValue for s in secrets.secrets}]
             else:
+                if raw:
+                    return [clean_secret_dict(s.to_dict()) for s in secrets.secrets]
                 return [{"value": s.secretValue, "key": s.secretKey} for s in secrets.secrets]
         except Exception as e:
             raise AnsibleError(f"Error fetching secrets: {e}")

--- a/plugins/module_utils/_authenticator.py
+++ b/plugins/module_utils/_authenticator.py
@@ -1,0 +1,175 @@
+"""Infisical SDK Authenticator for Ansible Collection.
+
+This module provides a centralized authentication mechanism for all Infisical
+plugins and modules. It uses the Infisical Python SDK for all operations.
+"""
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+# Authentication method constants
+AUTH_METHOD_UNIVERSAL_AUTH = "universal_auth"
+AUTH_METHOD_OIDC_AUTH = "oidc_auth"
+AUTH_METHOD_TOKEN_AUTH = "token_auth"
+
+SUPPORTED_AUTH_METHODS = [
+    AUTH_METHOD_UNIVERSAL_AUTH,
+    AUTH_METHOD_OIDC_AUTH,
+    AUTH_METHOD_TOKEN_AUTH,
+]
+
+# SDK availability flags
+HAS_INFISICAL = False
+INFISICAL_IMP_ERR = None
+INFISICAL_VERSION = None
+
+try:
+    from infisical_sdk import InfisicalSDKClient
+    HAS_INFISICAL = True
+except ImportError as e:
+    HAS_INFISICAL = False
+    INFISICAL_IMP_ERR = str(e)
+    InfisicalSDKClient = None
+
+if HAS_INFISICAL:
+    try:
+        from importlib.metadata import version
+        INFISICAL_VERSION = version('infisicalsdk')
+    except ImportError:
+        try:
+            import pkg_resources
+            INFISICAL_VERSION = pkg_resources.get_distribution('infisicalsdk').version
+        except Exception:
+            INFISICAL_VERSION = "unknown"
+    except Exception:
+        INFISICAL_VERSION = "unknown"
+
+
+def _parse_version_tuple(version_string):
+    """Parse a version string into a tuple of integers for comparison.
+    
+    Args:
+        version_string: A version string like "1.2.3" or "1.2"
+        
+    Returns:
+        A tuple of 3 integers (major, minor, patch)
+    """
+    if version_string == "unknown":
+        return (0, 0, 0)
+    
+    try:
+        parts = version_string.split('.')
+        while len(parts) < 3:
+            parts.append('0')
+        return tuple(int(part) for part in parts[:3])
+    except (ValueError, AttributeError):
+        return (0, 0, 0)
+
+
+def check_minimum_version(current_version, minimum_version):
+    """Check if current version meets minimum requirement.
+    
+    Args:
+        current_version: The current version string
+        minimum_version: The minimum required version string
+        
+    Returns:
+        True if current_version >= minimum_version
+    """
+    current_tuple = _parse_version_tuple(current_version)
+    minimum_tuple = _parse_version_tuple(minimum_version)
+    return current_tuple >= minimum_tuple
+
+
+class InfisicalAuthenticator:
+    """Authenticator for a single Infisical authentication flow.
+    
+    This class handles authentication with Infisical using the Python SDK.
+    All required parameters are passed to the constructor.
+    
+    Usage:
+        authenticator = InfisicalAuthenticator(
+            url="https://app.infisical.com",
+            auth_method="universal_auth",
+            client_id="...",
+            client_secret="..."
+        )
+        client = authenticator.authenticate()
+    """
+    
+    def __init__(self, url="https://app.infisical.com", auth_method="universal_auth", **credentials):
+        """Initialize the authenticator with all required parameters.
+        
+        Args:
+            url: The Infisical instance URL (default: https://app.infisical.com)
+            auth_method: The authentication method to use
+            **credentials: The credentials for the auth method:
+                - universal_auth: client_id, client_secret
+                - oidc_auth: identity_id, jwt
+                - token_auth: token
+        """
+        self.url = url
+        self.auth_method = auth_method
+        self.credentials = credentials
+        self._client = None
+    
+    def _validate(self):
+        """Validate credentials for the configured authentication method.
+        
+        Raises:
+            ValueError: If credentials are invalid or auth method is unsupported
+        """
+        method = self.auth_method
+        credentials = self.credentials
+        
+        if method not in SUPPORTED_AUTH_METHODS:
+            raise ValueError(f"Invalid auth method '{method}'. Supported: {', '.join(SUPPORTED_AUTH_METHODS)}")
+        
+        if method == AUTH_METHOD_UNIVERSAL_AUTH:
+            if not credentials.get('client_id') or not credentials.get('client_secret'):
+                raise ValueError("client_id and client_secret are required for universal_auth.")
+        
+        elif method == AUTH_METHOD_OIDC_AUTH:
+            if not check_minimum_version(INFISICAL_VERSION, "1.0.10"):
+                raise ValueError("Please upgrade infisicalsdk to at least 1.0.10 to use oidc_auth.")
+            if not credentials.get('identity_id') or not credentials.get('jwt'):
+                raise ValueError("identity_id and jwt are required for oidc_auth.")
+        
+        elif method == AUTH_METHOD_TOKEN_AUTH:
+            if not credentials.get('token'):
+                raise ValueError("token is required for token_auth.")
+    
+    def authenticate(self):
+        """Authenticate with Infisical and return a configured SDK client.
+        
+        Returns:
+            An authenticated InfisicalSDKClient instance
+            
+        Raises:
+            ValueError: If credentials are invalid
+            ImportError: If the Infisical SDK is not installed
+        """
+        if not HAS_INFISICAL:
+            raise ImportError(
+                f"The infisicalsdk package is required. Install with: pip install infisicalsdk. Error: {INFISICAL_IMP_ERR}"
+            )
+        
+        self._validate()
+        
+        client = InfisicalSDKClient(host=self.url)
+        
+        if self.auth_method == AUTH_METHOD_UNIVERSAL_AUTH:
+            client.auth.universal_auth.login(
+                self.credentials['client_id'],
+                self.credentials['client_secret']
+            )
+        elif self.auth_method == AUTH_METHOD_OIDC_AUTH:
+            client.auth.oidc_auth.login(
+                self.credentials['identity_id'],
+                self.credentials['jwt']
+            )
+        elif self.auth_method == AUTH_METHOD_TOKEN_AUTH:
+            client.auth.token_auth.login(self.credentials['token'])
+        
+        self._client = client
+        return client

--- a/plugins/module_utils/_secrets.py
+++ b/plugins/module_utils/_secrets.py
@@ -1,0 +1,23 @@
+"""Secret utilities for Infisical Ansible Collection.
+
+This module provides helper functions for working with secrets.
+"""
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+# Fields to exclude from secret responses (internal fields that are not relevant to the user or deprecated, duplicates of other fields)
+EXCLUDED_SECRET_FIELDS = ('_id', 'metadata')
+
+def clean_secret_dict(secret_dict):
+    """Remove deprecated fields from a secret dictionary.
+    
+    Args:
+        secret_dict: A dictionary from secret.to_dict()
+        
+    Returns:
+        A new dictionary with deprecated fields removed
+    """
+    return {k: v for k, v in secret_dict.items() if k not in EXCLUDED_SECRET_FIELDS}
+

--- a/plugins/modules/create_secret.py
+++ b/plugins/modules/create_secret.py
@@ -1,0 +1,283 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: create_secret
+short_description: Create a secret in Infisical
+version_added: "1.2.0"
+author:
+  - Infisical Inc.
+description:
+  - Create a new secret in Infisical.
+  - The secret will be created at the specified path and environment.
+extends_documentation_fragment:
+  - infisical.vault.auth
+
+options:
+  project_id:
+    description: The ID of the project where the secret will be created.
+    type: str
+    required: true
+  env_slug:
+    description: >
+      The environment slug where the secret will be created.
+      Environment slug is the short name of a given environment.
+    type: str
+    required: true
+  path:
+    description: "The folder path where the secret will be created. For example: /services/backend"
+    type: str
+    required: true
+  secret_name:
+    description: The name of the secret to create.
+    type: str
+    required: true
+  secret_value:
+    description: The value of the secret.
+    type: str
+    required: true
+    no_log: true
+  secret_comment:
+    description: An optional comment for the secret.
+    type: str
+  tags_ids:
+    description: A list of tag IDs to attach to the secret.
+    type: list
+    elements: str
+  skip_multiline_encoding:
+    description: Whether to skip multiline encoding for the secret value.
+    type: bool
+    default: false
+  secret_reminder_note:
+    description: A note for the secret reminder.
+    type: str
+  secret_reminder_repeat_days:
+    description: Number of days between secret reminder repeats.
+    type: int
+  secret_metadata:
+    description: A list of metadata key-value pairs to attach to the secret.
+    type: list
+    elements: dict
+
+seealso:
+  - module: infisical.vault.login
+    description: Use the login module to authenticate once and reuse the session.
+  - module: infisical.vault.read_secrets
+    description: Read secrets from Infisical.
+  - module: infisical.vault.update_secret
+    description: Update an existing secret.
+  - module: infisical.vault.delete_secret
+    description: Delete a secret.
+"""
+
+EXAMPLES = r"""
+# Create a secret with direct authentication
+- name: Create a new secret
+  infisical.vault.create_secret:
+    url: "https://app.infisical.com"
+    auth_method: universal_auth
+    universal_auth_client_id: "{{ client_id }}"
+    universal_auth_client_secret: "{{ client_secret }}"
+    project_id: "my-project-id"
+    env_slug: "dev"
+    path: "/"
+    secret_name: "DATABASE_URL"
+    secret_value: "postgres://localhost:5432/mydb"
+  register: created_secret
+
+# Create a secret using login_data
+- name: Login to Infisical
+  infisical.vault.login:
+    url: "https://app.infisical.com"
+    auth_method: universal_auth
+    universal_auth_client_id: "{{ client_id }}"
+    universal_auth_client_secret: "{{ client_secret }}"
+  register: infisical_login
+
+- name: Create a secret with comment
+  infisical.vault.create_secret:
+    login_data: "{{ infisical_login.login_data }}"
+    project_id: "my-project-id"
+    env_slug: "prod"
+    path: "/database"
+    secret_name: "DB_PASSWORD"
+    secret_value: "super-secret-password"
+    secret_comment: "Production database password"
+  register: created_secret
+"""
+
+RETURN = r"""
+secret:
+  description: The created secret.
+  returned: success
+  type: dict
+  contains:
+    id:
+      description: The unique identifier of the secret.
+      type: str
+    workspace:
+      description: The workspace/project ID where the secret resides.
+      type: str
+    environment:
+      description: The environment slug.
+      type: str
+    version:
+      description: The version number of the secret.
+      type: int
+    type:
+      description: The type of secret (shared or personal).
+      type: str
+    secretKey:
+      description: The name of the secret.
+      type: str
+    secretValue:
+      description: The value of the secret.
+      type: str
+    secretComment:
+      description: The comment associated with the secret.
+      type: str
+    createdAt:
+      description: The creation timestamp.
+      type: str
+    updatedAt:
+      description: The last update timestamp.
+      type: str
+    secretMetadata:
+      description: Additional metadata for the secret.
+      type: dict
+    secretValueHidden:
+      description: Whether the secret value is hidden.
+      type: bool
+    secretReminderNote:
+      description: A note for the secret reminder.
+      type: str
+    secretReminderRepeatDays:
+      description: Number of days between secret reminder repeats.
+      type: int
+    skipMultilineEncoding:
+      description: Whether multiline encoding was skipped.
+      type: bool
+    secretPath:
+      description: The path where the secret is stored.
+      type: str
+    tags:
+      description: List of tags attached to the secret.
+      type: list
+      elements: dict
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.infisical.vault.plugins.module_utils._authenticator import (
+    InfisicalAuthenticator,
+    create_client_from_login_data,
+)
+from ansible_collections.infisical.vault.plugins.module_utils._secrets import (
+    clean_secret_dict,
+)
+
+
+def get_sdk_client(module, login_data=None):
+    """Get an authenticated Infisical SDK client."""
+    if login_data is not None:
+        try:
+            return create_client_from_login_data(login_data)
+        except (ImportError, ValueError) as e:
+            module.fail_json(msg=str(e))
+    
+    try:
+        authenticator = InfisicalAuthenticator(
+            url=module.params['url'],
+            auth_method=module.params['auth_method'],
+            client_id=module.params['universal_auth_client_id'],
+            client_secret=module.params['universal_auth_client_secret'],
+            identity_id=module.params['identity_id'],
+            jwt=module.params['jwt'],
+            token=module.params['token'],
+        )
+        return authenticator.authenticate()
+    except (ImportError, ValueError) as e:
+        module.fail_json(msg=str(e))
+
+
+def run_module():
+    module_args = dict(
+        login_data=dict(type='dict', no_log=True),
+        url=dict(type='str', default='https://app.infisical.com'),
+        auth_method=dict(
+            type='str',
+            default='universal_auth',
+            choices=['universal_auth', 'oidc_auth', 'token_auth']
+        ),
+        universal_auth_client_id=dict(type='str'),
+        universal_auth_client_secret=dict(type='str', no_log=True),
+        identity_id=dict(type='str'),
+        jwt=dict(type='str', no_log=True),
+        token=dict(type='str', no_log=True),
+        project_id=dict(type='str', required=True),
+        env_slug=dict(type='str', required=True),
+        path=dict(type='str', required=True),
+        secret_name=dict(type='str', required=True),
+        secret_value=dict(type='str', required=True, no_log=True),
+        secret_comment=dict(type='str'),
+        tags_ids=dict(type='list', elements='str'),
+        skip_multiline_encoding=dict(type='bool', default=False),
+        secret_reminder_note=dict(type='str'),
+        secret_reminder_repeat_days=dict(type='int'),
+        secret_metadata=dict(type='list', elements='dict'),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    if module.check_mode:
+        module.exit_json(
+            changed=True,
+            secret={'secretKey': module.params['secret_name'], 'secretValue': '<check_mode>'},
+        )
+
+    try:
+        login_data = module.params.get('login_data')
+        client = get_sdk_client(module, login_data=login_data)
+        
+        create_kwargs = dict(
+            secret_name=module.params['secret_name'],
+            secret_value=module.params['secret_value'],
+            project_id=module.params['project_id'],
+            environment_slug=module.params['env_slug'],
+            secret_path=module.params['path'],
+        )
+        
+        if module.params.get('secret_comment'):
+            create_kwargs['secret_comment'] = module.params['secret_comment']
+        if module.params.get('tags_ids'):
+            create_kwargs['tags_ids'] = module.params['tags_ids']
+        if module.params.get('skip_multiline_encoding'):
+            create_kwargs['skip_multiline_encoding'] = module.params['skip_multiline_encoding']
+        if module.params.get('secret_reminder_note'):
+            create_kwargs['secret_reminder_note'] = module.params['secret_reminder_note']
+        if module.params.get('secret_reminder_repeat_days'):
+            create_kwargs['secret_reminder_repeat_days'] = module.params['secret_reminder_repeat_days']
+        if module.params.get('secret_metadata'):
+            create_kwargs['secret_metadata'] = module.params['secret_metadata']
+        
+        secret = client.secrets.create_secret_by_name(**create_kwargs)
+        
+        module.exit_json(
+            changed=True,
+            secret=clean_secret_dict(secret.to_dict()),
+        )
+    except Exception as e:
+        module.fail_json(msg=f"Error creating secret: {e}")
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()
+

--- a/plugins/modules/create_secret.py
+++ b/plugins/modules/create_secret.py
@@ -251,17 +251,17 @@ def run_module():
             secret_path=module.params['path'],
         )
         
-        if module.params.get('secret_comment'):
+        if module.params.get('secret_comment') is not None:
             create_kwargs['secret_comment'] = module.params['secret_comment']
-        if module.params.get('tags_ids'):
+        if module.params.get('tags_ids') is not None:
             create_kwargs['tags_ids'] = module.params['tags_ids']
-        if module.params.get('skip_multiline_encoding'):
+        if module.params.get('skip_multiline_encoding') is not None:
             create_kwargs['skip_multiline_encoding'] = module.params['skip_multiline_encoding']
-        if module.params.get('secret_reminder_note'):
+        if module.params.get('secret_reminder_note') is not None:
             create_kwargs['secret_reminder_note'] = module.params['secret_reminder_note']
-        if module.params.get('secret_reminder_repeat_days'):
+        if module.params.get('secret_reminder_repeat_days') is not None:
             create_kwargs['secret_reminder_repeat_days'] = module.params['secret_reminder_repeat_days']
-        if module.params.get('secret_metadata'):
+        if module.params.get('secret_metadata') is not None:
             create_kwargs['secret_metadata'] = module.params['secret_metadata']
         
         secret = client.secrets.create_secret_by_name(**create_kwargs)

--- a/plugins/modules/delete_secret.py
+++ b/plugins/modules/delete_secret.py
@@ -1,0 +1,231 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: delete_secret
+short_description: Delete a secret from Infisical
+version_added: "1.2.0"
+author:
+  - Infisical Inc.
+description:
+  - Delete a secret from Infisical by its name.
+  - The secret must exist at the specified path and environment.
+extends_documentation_fragment:
+  - infisical.vault.auth
+
+options:
+  project_id:
+    description: The ID of the project where the secret is stored.
+    type: str
+    required: true
+  env_slug:
+    description: >
+      The environment slug where the secret is stored.
+      Environment slug is the short name of a given environment.
+    type: str
+    required: true
+  path:
+    description: "The folder path where the secret resides. For example: /services/backend"
+    type: str
+    required: true
+  secret_name:
+    description: The name of the secret to delete.
+    type: str
+    required: true
+
+seealso:
+  - module: infisical.vault.login
+    description: Use the login module to authenticate once and reuse the session.
+  - module: infisical.vault.read_secrets
+    description: Read secrets from Infisical.
+  - module: infisical.vault.create_secret
+    description: Create a new secret.
+  - module: infisical.vault.update_secret
+    description: Update an existing secret.
+"""
+
+EXAMPLES = r"""
+# Delete a secret with direct authentication
+- name: Delete a secret
+  infisical.vault.delete_secret:
+    url: "https://app.infisical.com"
+    auth_method: universal_auth
+    universal_auth_client_id: "{{ client_id }}"
+    universal_auth_client_secret: "{{ client_secret }}"
+    project_id: "my-project-id"
+    env_slug: "dev"
+    path: "/"
+    secret_name: "OLD_SECRET"
+  register: deleted_secret
+
+# Delete a secret using login_data
+- name: Login to Infisical
+  infisical.vault.login:
+    url: "https://app.infisical.com"
+    auth_method: universal_auth
+    universal_auth_client_id: "{{ client_id }}"
+    universal_auth_client_secret: "{{ client_secret }}"
+  register: infisical_login
+
+- name: Delete a secret
+  infisical.vault.delete_secret:
+    login_data: "{{ infisical_login.login_data }}"
+    project_id: "my-project-id"
+    env_slug: "prod"
+    path: "/database"
+    secret_name: "DEPRECATED_SECRET"
+  register: deleted_secret
+"""
+
+RETURN = r"""
+secret:
+  description: The deleted secret.
+  returned: success
+  type: dict
+  contains:
+    id:
+      description: The unique identifier of the secret.
+      type: str
+    workspace:
+      description: The workspace/project ID where the secret resided.
+      type: str
+    environment:
+      description: The environment slug.
+      type: str
+    version:
+      description: The version number of the secret.
+      type: int
+    type:
+      description: The type of secret (shared or personal).
+      type: str
+    secretKey:
+      description: The name of the secret.
+      type: str
+    secretValue:
+      description: The value of the secret.
+      type: str
+    secretComment:
+      description: The comment associated with the secret.
+      type: str
+    createdAt:
+      description: The creation timestamp.
+      type: str
+    updatedAt:
+      description: The last update timestamp.
+      type: str
+    secretMetadata:
+      description: Additional metadata for the secret.
+      type: dict
+    secretValueHidden:
+      description: Whether the secret value is hidden.
+      type: bool
+    secretReminderNote:
+      description: A note for the secret reminder.
+      type: str
+    secretReminderRepeatDays:
+      description: Number of days between secret reminder repeats.
+      type: int
+    skipMultilineEncoding:
+      description: Whether multiline encoding was skipped.
+      type: bool
+    secretPath:
+      description: The path where the secret was stored.
+      type: str
+    tags:
+      description: List of tags that were attached to the secret.
+      type: list
+      elements: dict
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.infisical.vault.plugins.module_utils._authenticator import (
+    InfisicalAuthenticator,
+    create_client_from_login_data,
+)
+from ansible_collections.infisical.vault.plugins.module_utils._secrets import (
+    clean_secret_dict,
+)
+
+
+def get_sdk_client(module, login_data=None):
+    """Get an authenticated Infisical SDK client."""
+    if login_data is not None:
+        try:
+            return create_client_from_login_data(login_data)
+        except (ImportError, ValueError) as e:
+            module.fail_json(msg=str(e))
+    
+    try:
+        authenticator = InfisicalAuthenticator(
+            url=module.params['url'],
+            auth_method=module.params['auth_method'],
+            client_id=module.params['universal_auth_client_id'],
+            client_secret=module.params['universal_auth_client_secret'],
+            identity_id=module.params['identity_id'],
+            jwt=module.params['jwt'],
+            token=module.params['token'],
+        )
+        return authenticator.authenticate()
+    except (ImportError, ValueError) as e:
+        module.fail_json(msg=str(e))
+
+
+def run_module():
+    module_args = dict(
+        login_data=dict(type='dict', no_log=True),
+        url=dict(type='str', default='https://app.infisical.com'),
+        auth_method=dict(
+            type='str',
+            default='universal_auth',
+            choices=['universal_auth', 'oidc_auth', 'token_auth']
+        ),
+        universal_auth_client_id=dict(type='str'),
+        universal_auth_client_secret=dict(type='str', no_log=True),
+        identity_id=dict(type='str'),
+        jwt=dict(type='str', no_log=True),
+        token=dict(type='str', no_log=True),
+        project_id=dict(type='str', required=True),
+        env_slug=dict(type='str', required=True),
+        path=dict(type='str', required=True),
+        secret_name=dict(type='str', required=True),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    if module.check_mode:
+        module.exit_json(
+            changed=True,
+            secret={'secretKey': module.params['secret_name']},
+        )
+
+    try:
+        login_data = module.params.get('login_data')
+        client = get_sdk_client(module, login_data=login_data)
+        
+        secret = client.secrets.delete_secret_by_name(
+            secret_name=module.params['secret_name'],
+            project_id=module.params['project_id'],
+            environment_slug=module.params['env_slug'],
+            secret_path=module.params['path'],
+        )
+        
+        module.exit_json(
+            changed=True,
+            secret=clean_secret_dict(secret.to_dict()),
+        )
+    except Exception as e:
+        module.fail_json(msg=f"Error deleting secret: {e}")
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()
+

--- a/plugins/modules/login.py
+++ b/plugins/modules/login.py
@@ -1,0 +1,143 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: login
+short_description: Perform a login operation against Infisical
+version_added: "1.2.0"
+author:
+  - Infisical Inc.
+description:
+  - Performs a login operation against Infisical, returning login data containing an access token.
+  - The login data can be registered and reused across multiple subsequent tasks to avoid repeated authentication.
+  - This is useful for playbooks that need to fetch multiple secrets, as it reduces the number of authentication requests.
+extends_documentation_fragment:
+  - infisical.vault.auth.login
+
+seealso:
+  - module: infisical.vault.read_secrets
+    description: Use the login data with read_secrets to fetch secrets without re-authenticating.
+
+notes:
+  - The returned login data contains the access token and can be registered for reuse in subsequent tasks.
+"""
+
+EXAMPLES = r"""
+# Login with universal auth and register the result
+- name: Login to Infisical
+  infisical.vault.login:
+    url: "https://app.infisical.com"
+    auth_method: universal_auth
+    universal_auth_client_id: "{{ client_id }}"
+    universal_auth_client_secret: "{{ client_secret }}"
+  register: infisical_login
+
+# Use the registered login data with read_secrets
+- name: Read secrets using cached login
+  infisical.vault.read_secrets:
+    login_data: "{{ infisical_login.login_data }}"
+    project_id: "my-project-id"
+    env_slug: "prod"
+    path: "/"
+  register: secrets
+
+# Login with OIDC auth
+- name: Login with OIDC
+  infisical.vault.login:
+    auth_method: oidc_auth
+    identity_id: "{{ identity_id }}"
+    jwt: "{{ jwt_token }}"
+  register: infisical_login
+
+# Login with token auth
+- name: Login with token
+  infisical.vault.login:
+    auth_method: token_auth
+    token: "{{ my_token }}"
+  register: infisical_login
+"""
+
+RETURN = r"""
+login_data:
+  description: >
+    A dictionary containing the login data that can be passed directly to other modules.
+    Use C({{ infisical_login.login_data }}) when passing to C(read_secrets) for example.
+  returned: success
+  type: dict
+  contains:
+    url:
+      description: The Infisical instance URL.
+      type: str
+    access_token:
+      description: The access token for API authentication.
+      type: str
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.infisical.vault.plugins.module_utils._authenticator import (
+    InfisicalAuthenticator,
+)
+
+def run_module():
+    module_args = dict(
+        url=dict(type='str', default='https://app.infisical.com'),
+        auth_method=dict(
+            type='str',
+            default='universal_auth',
+            choices=['universal_auth', 'oidc_auth', 'token_auth']
+        ),
+        universal_auth_client_id=dict(type='str'),
+        universal_auth_client_secret=dict(type='str', no_log=True),
+        identity_id=dict(type='str'),
+        jwt=dict(type='str', no_log=True),
+        token=dict(type='str', no_log=True),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    # In check mode, just return success without actually authenticating
+    if module.check_mode:
+        check_login_data = {
+            'url': module.params['url'],
+            'access_token': '<check_mode_token>',
+        }
+        module.exit_json(
+            changed=False,
+            login_data=check_login_data
+        )
+
+    try:
+        authenticator = InfisicalAuthenticator(
+            url=module.params['url'],
+            auth_method=module.params['auth_method'],
+            client_id=module.params['universal_auth_client_id'],
+            client_secret=module.params['universal_auth_client_secret'],
+            identity_id=module.params['identity_id'],
+            jwt=module.params['jwt'],
+            token=module.params['token'],
+        )
+        
+        login_data = authenticator.login()
+        
+        module.exit_json(
+            changed=False,
+            login_data=login_data
+        )
+    except (ImportError, ValueError) as e:
+        module.fail_json(msg=str(e))
+    except Exception as e:
+        module.fail_json(msg=f"Unexpected error during login: {e}")
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()
+

--- a/plugins/modules/read_secrets.py
+++ b/plugins/modules/read_secrets.py
@@ -1,0 +1,347 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: read_secrets
+short_description: Read secrets from Infisical
+version_added: "1.2.0"
+author:
+  - Infisical Inc.
+description:
+  - Retrieve secrets from Infisical, granted the caller has the right permissions to access the secret.
+  - Secrets can be located either by their name for individual secret lookups or by environment/folder path to return all secrets within the given scope.
+  - You can either provide authentication credentials directly, or use C(login_data) from a previous C(infisical.vault.login) task to reuse an authenticated session.
+extends_documentation_fragment:
+  - infisical.vault.auth
+
+options:
+  project_id:
+    description: The ID of the project where the secrets are stored.
+    type: str
+    required: true
+  env_slug:
+    description: >
+      The environment slug to fetch secrets from.
+      Environment slug is the short name of a given environment.
+    type: str
+    required: true
+  path:
+    description: "The folder path where the requested secret resides. For example: /services/backend"
+    type: str
+    required: true
+  secret_name:
+    description: >
+      The name of the secret that should be fetched.
+      The name should be exactly as it appears in Infisical.
+      If not provided, all secrets at the given path will be returned.
+    type: str
+  as_dict:
+    description: >
+      Return the listed secrets as a dictionary instead of a list of key-value pairs.
+      When True, returns {'SECRET_KEY': 'secret_value', ...} instead of [{'key': 'SECRET_KEY', 'value': 'secret_value'}, ...].
+      This only applies when reading all secrets within a scope, not when reading a single secret by name.
+    type: bool
+    default: false
+  raw:
+    description: >
+      Return the full secret object with all properties instead of just key/value.
+      When True, returns all secret metadata including id, version, type, secretComment, createdAt, updatedAt, tags, etc.
+      When combined with C(as_dict=True), returns a dictionary where keys are secret names and values are full secret objects.
+    type: bool
+    default: false
+
+seealso:
+  - module: infisical.vault.login
+    description: Use the login module to authenticate once and reuse the session.
+"""
+
+EXAMPLES = r"""
+# Direct authentication (authenticates on each call)
+- name: Read all secrets in a path
+  infisical.vault.read_secrets:
+    url: "https://app.infisical.com"
+    auth_method: universal_auth
+    universal_auth_client_id: "{{ client_id }}"
+    universal_auth_client_secret: "{{ client_secret }}"
+    project_id: "my-project-id"
+    env_slug: "dev"
+    path: "/"
+  register: all_secrets
+
+# Read secrets as a dictionary
+- name: Read all secrets as dict
+  infisical.vault.read_secrets:
+    url: "https://app.infisical.com"
+    auth_method: universal_auth
+    universal_auth_client_id: "{{ client_id }}"
+    universal_auth_client_secret: "{{ client_secret }}"
+    project_id: "my-project-id"
+    env_slug: "dev"
+    path: "/"
+    as_dict: true
+  register: secrets_dict
+
+# Using login_data from infisical.vault.login (recommended for multiple calls)
+- name: Login to Infisical once
+  infisical.vault.login:
+    url: "https://app.infisical.com"
+    auth_method: universal_auth
+    universal_auth_client_id: "{{ client_id }}"
+    universal_auth_client_secret: "{{ client_secret }}"
+  register: infisical_login
+
+- name: Read database secrets using cached login
+  infisical.vault.read_secrets:
+    login_data: "{{ infisical_login.login_data }}"
+    project_id: "my-project-id"
+    env_slug: "prod"
+    path: "/database"
+  register: db_secrets
+
+- name: Read API secrets using the same login (no re-authentication)
+  infisical.vault.read_secrets:
+    login_data: "{{ infisical_login.login_data }}"
+    project_id: "my-project-id"
+    env_slug: "prod"
+    path: "/api"
+  register: api_secrets
+
+# Read a specific secret by name
+- name: Read a specific secret
+  infisical.vault.read_secrets:
+    login_data: "{{ infisical_login.login_data }}"
+    project_id: "my-project-id"
+    env_slug: "prod"
+    path: "/"
+    secret_name: "DATABASE_URL"
+  register: db_url_secret
+
+# Using raw=True to get full secret metadata
+- name: Read all secrets with full metadata
+  infisical.vault.read_secrets:
+    login_data: "{{ infisical_login.login_data }}"
+    project_id: "my-project-id"
+    env_slug: "dev"
+    path: "/"
+    raw: true
+  register: raw_secrets
+  # Returns secrets with all properties: id, version, type, secretComment, createdAt, updatedAt, tags, etc.
+
+- name: Read all secrets with full metadata as dict
+  infisical.vault.read_secrets:
+    login_data: "{{ infisical_login.login_data }}"
+    project_id: "my-project-id"
+    env_slug: "dev"
+    path: "/"
+    raw: true
+    as_dict: true
+  register: raw_secrets_dict
+  # Returns: {"SECRET_NAME": {"id": "...", "secretKey": "SECRET_NAME", "secretValue": "...", "version": 1, ...}, ...}
+"""
+
+RETURN = r"""
+secrets:
+  description: >
+    The secrets retrieved from Infisical.
+    When C(secret_name) is provided, returns a list with a single secret.
+    When C(as_dict) is True, returns a dictionary of secret key-value pairs.
+    When C(raw) is True, returns full secret objects with all properties.
+    When C(raw) and C(as_dict) are both True, returns a dictionary mapping secret names to full secret objects.
+  returned: success
+  type: raw
+  sample:
+    - key: "DATABASE_URL"
+      value: "postgres://localhost:5432/db"
+  contains:
+    key:
+      description: The name of the secret (when C(raw=False)).
+      type: str
+    value:
+      description: The value of the secret (when C(raw=False)).
+      type: str
+    id:
+      description: The unique identifier of the secret (when C(raw=True)).
+      type: str
+    workspace:
+      description: The workspace/project ID where the secret resides (when C(raw=True)).
+      type: str
+    environment:
+      description: The environment slug (when C(raw=True)).
+      type: str
+    version:
+      description: The version number of the secret (when C(raw=True)).
+      type: int
+    type:
+      description: The type of secret - shared or personal (when C(raw=True)).
+      type: str
+    secretKey:
+      description: The name of the secret (when C(raw=True)).
+      type: str
+    secretValue:
+      description: The value of the secret (when C(raw=True)).
+      type: str
+    secretComment:
+      description: The comment associated with the secret (when C(raw=True)).
+      type: str
+    createdAt:
+      description: The creation timestamp (when C(raw=True)).
+      type: str
+    updatedAt:
+      description: The last update timestamp (when C(raw=True)).
+      type: str
+    secretMetadata:
+      description: Additional metadata for the secret (when C(raw=True)).
+      type: dict
+    secretValueHidden:
+      description: Whether the secret value is hidden (when C(raw=True)).
+      type: bool
+    secretReminderNote:
+      description: A note for the secret reminder (when C(raw=True)).
+      type: str
+    secretReminderRepeatDays:
+      description: Number of days between secret reminder repeats (when C(raw=True)).
+      type: int
+    skipMultilineEncoding:
+      description: Whether multiline encoding was skipped (when C(raw=True)).
+      type: bool
+    secretPath:
+      description: The path where the secret is stored (when C(raw=True)).
+      type: str
+    tags:
+      description: List of tags attached to the secret (when C(raw=True)).
+      type: list
+      elements: dict
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.infisical.vault.plugins.module_utils._authenticator import (
+    InfisicalAuthenticator,
+    create_client_from_login_data,
+)
+from ansible_collections.infisical.vault.plugins.module_utils._secrets import (
+    clean_secret_dict,
+)
+
+
+def get_sdk_client(module, login_data=None):
+    """Get an authenticated Infisical SDK client."""
+    if login_data is not None:
+        try:
+            return create_client_from_login_data(login_data)
+        except (ImportError, ValueError) as e:
+            module.fail_json(msg=str(e))
+    
+    # Otherwise, authenticate fresh
+    try:
+        authenticator = InfisicalAuthenticator(
+            url=module.params['url'],
+            auth_method=module.params['auth_method'],
+            client_id=module.params['universal_auth_client_id'],
+            client_secret=module.params['universal_auth_client_secret'],
+            identity_id=module.params['identity_id'],
+            jwt=module.params['jwt'],
+            token=module.params['token'],
+        )
+        return authenticator.authenticate()
+    except (ImportError, ValueError) as e:
+        module.fail_json(msg=str(e))
+
+
+def get_single_secret(client, project_id, secret_name, environment, path, raw=False):
+    """Fetch a single secret by name."""
+    secret = client.secrets.get_secret_by_name(
+        secret_name=secret_name,
+        project_id=project_id,
+        environment_slug=environment,
+        secret_path=path
+    )
+    if raw:
+        return [clean_secret_dict(secret.to_dict())]
+    return [{"value": secret.secretValue, "key": secret.secretKey}]
+
+
+def get_all_secrets(client, project_id, environment, path, as_dict=False, raw=False):
+    """Fetch all secrets within the specified scope."""
+    secrets = client.secrets.list_secrets(
+        project_id=project_id,
+        environment_slug=environment,
+        secret_path=path
+    )
+
+    if as_dict:
+        if raw:
+            return {s.secretKey: clean_secret_dict(s.to_dict()) for s in secrets.secrets}
+        return {s.secretKey: s.secretValue for s in secrets.secrets}
+    else:
+        if raw:
+            return [clean_secret_dict(s.to_dict()) for s in secrets.secrets]
+        return [{"value": s.secretValue, "key": s.secretKey} for s in secrets.secrets]
+
+
+def run_module():
+    module_args = dict(
+        login_data=dict(type='dict', no_log=True),
+        url=dict(type='str', default='https://app.infisical.com'),
+        auth_method=dict(
+            type='str',
+            default='universal_auth',
+            choices=['universal_auth', 'oidc_auth', 'token_auth']
+        ),
+        universal_auth_client_id=dict(type='str'),
+        universal_auth_client_secret=dict(type='str', no_log=True),
+        identity_id=dict(type='str'),
+        jwt=dict(type='str', no_log=True),
+        token=dict(type='str', no_log=True),
+        project_id=dict(type='str', required=True),
+        env_slug=dict(type='str', required=True),
+        path=dict(type='str', required=True),
+        secret_name=dict(type='str'),
+        as_dict=dict(type='bool', default=False),
+        raw=dict(type='bool', default=False),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    # In check mode, just return success without actually fetching secrets
+    if module.check_mode:
+        module.exit_json(
+            changed=False,
+            secrets=[],
+        )
+
+    try:
+        login_data = module.params.get('login_data')
+        client = get_sdk_client(module, login_data=login_data)
+        
+        project_id = module.params['project_id']
+        env_slug = module.params['env_slug']
+        path = module.params['path']
+        secret_name = module.params.get('secret_name')
+        as_dict = module.params['as_dict']
+        raw = module.params['raw']
+        
+        if secret_name:
+            secrets = get_single_secret(client, project_id, secret_name, env_slug, path, raw)
+        else:
+            secrets = get_all_secrets(client, project_id, env_slug, path, as_dict, raw)
+        
+        module.exit_json(
+            changed=False,
+            secrets=secrets,
+        )
+    except Exception as e:
+        module.fail_json(msg=f"Error fetching secrets: {e}")
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()
+

--- a/plugins/modules/update_secret.py
+++ b/plugins/modules/update_secret.py
@@ -266,19 +266,19 @@ def run_module():
         
         if module.params.get('secret_value') is not None:
             update_kwargs['secret_value'] = module.params['secret_value']
-        if module.params.get('new_secret_name'):
+        if module.params.get('new_secret_name') is not None:
             update_kwargs['new_secret_name'] = module.params['new_secret_name']
         if module.params.get('secret_comment') is not None:
             update_kwargs['secret_comment'] = module.params['secret_comment']
-        if module.params.get('tags_ids'):
+        if module.params.get('tags_ids') is not None:
             update_kwargs['tags_ids'] = module.params['tags_ids']
-        if module.params.get('skip_multiline_encoding'):
+        if module.params.get('skip_multiline_encoding') is not None:
             update_kwargs['skip_multiline_encoding'] = module.params['skip_multiline_encoding']
         if module.params.get('secret_reminder_note') is not None:
             update_kwargs['secret_reminder_note'] = module.params['secret_reminder_note']
         if module.params.get('secret_reminder_repeat_days') is not None:
             update_kwargs['secret_reminder_repeat_days'] = module.params['secret_reminder_repeat_days']
-        if module.params.get('secret_metadata'):
+        if module.params.get('secret_metadata') is not None:
             update_kwargs['secret_metadata'] = module.params['secret_metadata']
         
         secret = client.secrets.update_secret_by_name(**update_kwargs)

--- a/plugins/modules/update_secret.py
+++ b/plugins/modules/update_secret.py
@@ -1,0 +1,300 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: update_secret
+short_description: Update a secret in Infisical
+version_added: "1.2.0"
+author:
+  - Infisical Inc.
+description:
+  - Update an existing secret in Infisical.
+  - The secret must already exist at the specified path and environment.
+extends_documentation_fragment:
+  - infisical.vault.auth
+
+options:
+  project_id:
+    description: The ID of the project where the secret is stored.
+    type: str
+    required: true
+  env_slug:
+    description: >
+      The environment slug where the secret is stored.
+      Environment slug is the short name of a given environment.
+    type: str
+    required: true
+  path:
+    description: "The folder path where the secret resides. For example: /services/backend"
+    type: str
+    required: true
+  secret_name:
+    description: The name of the secret to update.
+    type: str
+    required: true
+  secret_value:
+    description: The new value of the secret.
+    type: str
+    no_log: true
+  new_secret_name:
+    description: A new name for the secret (to rename it).
+    type: str
+  secret_comment:
+    description: An optional comment for the secret.
+    type: str
+  tags_ids:
+    description: A list of tag IDs to attach to the secret.
+    type: list
+    elements: str
+  skip_multiline_encoding:
+    description: Whether to skip multiline encoding for the secret value.
+    type: bool
+    default: false
+  secret_reminder_note:
+    description: A note for the secret reminder.
+    type: str
+  secret_reminder_repeat_days:
+    description: Number of days between secret reminder repeats.
+    type: int
+  secret_metadata:
+    description: A list of metadata key-value pairs to attach to the secret.
+    type: list
+    elements: dict
+
+seealso:
+  - module: infisical.vault.login
+    description: Use the login module to authenticate once and reuse the session.
+  - module: infisical.vault.read_secrets
+    description: Read secrets from Infisical.
+  - module: infisical.vault.create_secret
+    description: Create a new secret.
+  - module: infisical.vault.delete_secret
+    description: Delete a secret.
+"""
+
+EXAMPLES = r"""
+# Update a secret value with direct authentication
+- name: Update a secret value
+  infisical.vault.update_secret:
+    url: "https://app.infisical.com"
+    auth_method: universal_auth
+    universal_auth_client_id: "{{ client_id }}"
+    universal_auth_client_secret: "{{ client_secret }}"
+    project_id: "my-project-id"
+    env_slug: "dev"
+    path: "/"
+    secret_name: "DATABASE_URL"
+    secret_value: "postgres://localhost:5432/newdb"
+  register: updated_secret
+
+# Update a secret using login_data
+- name: Login to Infisical
+  infisical.vault.login:
+    url: "https://app.infisical.com"
+    auth_method: universal_auth
+    universal_auth_client_id: "{{ client_id }}"
+    universal_auth_client_secret: "{{ client_secret }}"
+  register: infisical_login
+
+- name: Update secret with new value and comment
+  infisical.vault.update_secret:
+    login_data: "{{ infisical_login.login_data }}"
+    project_id: "my-project-id"
+    env_slug: "prod"
+    path: "/database"
+    secret_name: "DB_PASSWORD"
+    secret_value: "new-super-secret-password"
+    secret_comment: "Updated production database password"
+  register: updated_secret
+
+# Rename a secret
+- name: Rename a secret
+  infisical.vault.update_secret:
+    login_data: "{{ infisical_login.login_data }}"
+    project_id: "my-project-id"
+    env_slug: "prod"
+    path: "/"
+    secret_name: "OLD_SECRET_NAME"
+    new_secret_name: "NEW_SECRET_NAME"
+  register: renamed_secret
+"""
+
+RETURN = r"""
+secret:
+  description: The updated secret.
+  returned: success
+  type: dict
+  contains:
+    id:
+      description: The unique identifier of the secret.
+      type: str
+    workspace:
+      description: The workspace/project ID where the secret resides.
+      type: str
+    environment:
+      description: The environment slug.
+      type: str
+    version:
+      description: The version number of the secret.
+      type: int
+    type:
+      description: The type of secret (shared or personal).
+      type: str
+    secretKey:
+      description: The name of the secret.
+      type: str
+    secretValue:
+      description: The value of the secret.
+      type: str
+    secretComment:
+      description: The comment associated with the secret.
+      type: str
+    createdAt:
+      description: The creation timestamp.
+      type: str
+    updatedAt:
+      description: The last update timestamp.
+      type: str
+    secretMetadata:
+      description: Additional metadata for the secret.
+      type: dict
+    secretValueHidden:
+      description: Whether the secret value is hidden.
+      type: bool
+    secretReminderNote:
+      description: A note for the secret reminder.
+      type: str
+    secretReminderRepeatDays:
+      description: Number of days between secret reminder repeats.
+      type: int
+    skipMultilineEncoding:
+      description: Whether multiline encoding was skipped.
+      type: bool
+    secretPath:
+      description: The path where the secret is stored.
+      type: str
+    tags:
+      description: List of tags attached to the secret.
+      type: list
+      elements: dict
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.infisical.vault.plugins.module_utils._authenticator import (
+    InfisicalAuthenticator,
+    create_client_from_login_data,
+)
+from ansible_collections.infisical.vault.plugins.module_utils._secrets import (
+    clean_secret_dict,
+)
+
+
+def get_sdk_client(module, login_data=None):
+    """Get an authenticated Infisical SDK client."""
+    if login_data is not None:
+        try:
+            return create_client_from_login_data(login_data)
+        except (ImportError, ValueError) as e:
+            module.fail_json(msg=str(e))
+    
+    try:
+        authenticator = InfisicalAuthenticator(
+            url=module.params['url'],
+            auth_method=module.params['auth_method'],
+            client_id=module.params['universal_auth_client_id'],
+            client_secret=module.params['universal_auth_client_secret'],
+            identity_id=module.params['identity_id'],
+            jwt=module.params['jwt'],
+            token=module.params['token'],
+        )
+        return authenticator.authenticate()
+    except (ImportError, ValueError) as e:
+        module.fail_json(msg=str(e))
+
+
+def run_module():
+    module_args = dict(
+        login_data=dict(type='dict', no_log=True),
+        url=dict(type='str', default='https://app.infisical.com'),
+        auth_method=dict(
+            type='str',
+            default='universal_auth',
+            choices=['universal_auth', 'oidc_auth', 'token_auth']
+        ),
+        universal_auth_client_id=dict(type='str'),
+        universal_auth_client_secret=dict(type='str', no_log=True),
+        identity_id=dict(type='str'),
+        jwt=dict(type='str', no_log=True),
+        token=dict(type='str', no_log=True),
+        project_id=dict(type='str', required=True),
+        env_slug=dict(type='str', required=True),
+        path=dict(type='str', required=True),
+        secret_name=dict(type='str', required=True),
+        secret_value=dict(type='str', no_log=True),
+        new_secret_name=dict(type='str'),
+        secret_comment=dict(type='str'),
+        tags_ids=dict(type='list', elements='str'),
+        skip_multiline_encoding=dict(type='bool', default=False),
+        secret_reminder_note=dict(type='str'),
+        secret_reminder_repeat_days=dict(type='int'),
+        secret_metadata=dict(type='list', elements='dict'),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    if module.check_mode:
+        module.exit_json(
+            changed=True,
+            secret={'secretKey': module.params['secret_name'], 'secretValue': '<check_mode>'},
+        )
+
+    try:
+        login_data = module.params.get('login_data')
+        client = get_sdk_client(module, login_data=login_data)
+        
+        update_kwargs = dict(
+            current_secret_name=module.params['secret_name'],
+            project_id=module.params['project_id'],
+            environment_slug=module.params['env_slug'],
+            secret_path=module.params['path'],
+        )
+        
+        if module.params.get('secret_value') is not None:
+            update_kwargs['secret_value'] = module.params['secret_value']
+        if module.params.get('new_secret_name'):
+            update_kwargs['new_secret_name'] = module.params['new_secret_name']
+        if module.params.get('secret_comment') is not None:
+            update_kwargs['secret_comment'] = module.params['secret_comment']
+        if module.params.get('tags_ids'):
+            update_kwargs['tags_ids'] = module.params['tags_ids']
+        if module.params.get('skip_multiline_encoding'):
+            update_kwargs['skip_multiline_encoding'] = module.params['skip_multiline_encoding']
+        if module.params.get('secret_reminder_note') is not None:
+            update_kwargs['secret_reminder_note'] = module.params['secret_reminder_note']
+        if module.params.get('secret_reminder_repeat_days') is not None:
+            update_kwargs['secret_reminder_repeat_days'] = module.params['secret_reminder_repeat_days']
+        if module.params.get('secret_metadata'):
+            update_kwargs['secret_metadata'] = module.params['secret_metadata']
+        
+        secret = client.secrets.update_secret_by_name(**update_kwargs)
+        
+        module.exit_json(
+            changed=True,
+            secret=clean_secret_dict(secret.to_dict()),
+        )
+    except Exception as e:
+        module.fail_json(msg=f"Error updating secret: {e}")
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
## Summary

This PR significantly expands the Infisical Ansible collection by adding new modules for complete secret lifecycle management (CRUD operations), introducing a centralized authentication system, and improving code maintainability through documentation fragments.

## Suggested Version

Due to the scope of changes and new functionality, this release should be versioned as **1.2.0** (minor version bump). 

## Changes

### New Modules

- **`login`** - Authenticate with Infisical and return reusable login data containing an access token
- **`read_secrets`** - Read secrets from Infisical (module version of existing lookup)
- **`create_secret`** - Create new secrets in Infisical
- **`update_secret`** - Update existing secrets in Infisical
- **`delete_secret`** - Delete secrets from Infisical

### New Lookup Plugins

- **`login`** - Lookup version of the login module for use in `set_fact` workflows

### Authentication Improvements

- Centralized authentication logic in `plugins/module_utils/_authenticator.py`
- Support for session reuse via `login_data` parameter across all modules and lookups
- Reduced authentication overhead when fetching multiple secrets in a playbook

### Documentation Fragments

- Added `plugins/doc_fragments/auth.py` with reusable authentication documentation
- Four fragment variants for different plugin types:
  - `auth` - Standard modules with `login_data` support
  - `auth.login` - Login module (no `login_data` option)
  - `auth.lookup` - Lookup plugins with environment variable support
  - `auth.lookup_login` - Login lookup (no `login_data` option)

### Utility Modules

- Added `plugins/module_utils/_secrets.py` with helper functions for secret handling
- Implemented `clean_secret_dict()` to filter deprecated fields (`_id`, `metadata`) from responses

### New Features

- **`raw` parameter** for `read_secrets` - Returns full secret metadata instead of just key/value pairs
- **`as_dict` parameter** - Returns secrets as a dictionary for easier access
- All modules support both direct authentication and `login_data` for session reuse

### Other Changes

- Updated `galaxy.yml` documentation URL to point to official Infisical docs

## Testing

### macOS Compatibility Note

When running `ansible-playbook` on macOS, you may encounter Python forking issues due to Objective-C runtime restrictions. To resolve this, set the following environment variable before running playbooks:

```bash
OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES ansible-playbook test_playbook.yml
```

### Test Cases Covered

**Lookup Plugin Tests:**

- Read all secrets with direct authentication
- Read secrets as dictionary (`as_dict=true`)
- Login lookup and session reuse
- Read secrets using cached `login_data`
- Read specific secret by name

**Module Tests:**
- Login module
- Read secrets module with direct authentication
- Read secrets module with `login_data` from login module
- Read secrets as dictionary using module
- Read specific secret by name using module

**Real-World Integration:**
- Fetch MongoDB credentials and use them with `community.mongodb.mongodb_shell` to insert a record

**Raw Mode Tests:**
- Read secrets with `raw=true` (lookup) - returns full metadata
- Read secrets with `raw=true` and `as_dict=true` (module)

**CRUD Operations:**
- Create a new secret with comment
- Read the created secret to verify
- Update the secret value and comment
- Delete the secret
- Verify secret deletion (expects error)