### PR TITLE
Feature/dynamic secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
 .venv/**/*
 ansible.cfg
+*_vars.yml
+*_vars.yaml
 inventory
 test.yml
 __pycache__
-infisical-vault-1.0.0.tar.gz
+*.tar.gz
 
 .vscode
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -254,8 +254,8 @@ Dynamic secrets generate credentials on-demand with automatic expiration. They s
 - name: Connect to database
   community.postgresql.postgresql_query:
     login_host: localhost
-    login_user: "{{ lease.data.username }}"
-    login_password: "{{ lease.data.password }}"
+    login_user: "{{ lease.data.DB_USERNAME }}"
+    login_password: "{{ lease.data.DB_USERNAME }}"
     db: mydb
     query: "SELECT version();"
 

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Dynamic secrets generate credentials on-demand with automatic expiration. They s
   community.postgresql.postgresql_query:
     login_host: localhost
     login_user: "{{ lease.data.DB_USERNAME }}"
-    login_password: "{{ lease.data.DB_USERNAME }}"
+    login_password: "{{ lease.data.DB_PASSWORD }}"
     db: mydb
     query: "SELECT version();"
 

--- a/README.md
+++ b/README.md
@@ -129,11 +129,25 @@ Token Auth allows you to authenticate directly with an access token. This can be
 - `infisical.vault.read_secrets` - Read secrets from Infisical
 
 ### Modules
+
+**Static Secrets:**
 - `infisical.vault.login` - Authenticate and return reusable login data
 - `infisical.vault.read_secrets` - Read secrets from Infisical
 - `infisical.vault.create_secret` - Create a new secret
 - `infisical.vault.update_secret` - Update an existing secret
 - `infisical.vault.delete_secret` - Delete a secret
+
+**Dynamic Secrets:**
+- `infisical.vault.create_dynamic_secret` - Create a dynamic secret
+- `infisical.vault.get_dynamic_secret` - Get a dynamic secret by name
+- `infisical.vault.update_dynamic_secret` - Update a dynamic secret
+- `infisical.vault.delete_dynamic_secret` - Delete a dynamic secret
+
+**Dynamic Secret Leases:**
+- `infisical.vault.create_dynamic_secret_lease` - Create a lease (generates credentials)
+- `infisical.vault.get_dynamic_secret_lease` - Get lease details
+- `infisical.vault.renew_dynamic_secret_lease` - Renew an existing lease
+- `infisical.vault.delete_dynamic_secret_lease` - Delete/revoke a lease
 
 ## Examples
 
@@ -196,4 +210,61 @@ Token Auth allows you to authenticate directly with an access token. This can be
     env_slug: "dev"
     path: "/"
     secret_name: "API_KEY"
+```
+
+### Dynamic Secrets
+
+Dynamic secrets generate credentials on-demand with automatic expiration. They support various providers like SQL databases, AWS, GCP, Azure, and more.
+
+```yaml
+# Create a dynamic secret for PostgreSQL
+- name: Create a PostgreSQL dynamic secret
+  infisical.vault.create_dynamic_secret:
+    login_data: "{{ infisical_login.login_data }}"
+    project_slug: "my-project"
+    env_slug: "dev"
+    path: "/"
+    name: "postgres-dev"
+    provider_type: "sql-database"
+    inputs:
+      client: "postgres"
+      host: "localhost"
+      port: 5432
+      database: "mydb"
+      username: "admin"
+      password: "admin-password"
+      creationStatement: "CREATE USER \"{{username}}\" WITH PASSWORD '{{password}}';"
+      revocationStatement: "DROP USER \"{{username}}\";"
+    default_ttl: "1h"
+    max_ttl: "24h"
+  register: dynamic_secret
+
+# Create a lease to get credentials
+- name: Get database credentials
+  infisical.vault.create_dynamic_secret_lease:
+    login_data: "{{ infisical_login.login_data }}"
+    project_slug: "my-project"
+    env_slug: "dev"
+    path: "/"
+    dynamic_secret_name: "postgres-dev"
+    ttl: "30m"
+  register: lease
+
+# Use the generated credentials
+- name: Connect to database
+  community.postgresql.postgresql_query:
+    login_host: localhost
+    login_user: "{{ lease.data.username }}"
+    login_password: "{{ lease.data.password }}"
+    db: mydb
+    query: "SELECT version();"
+
+# Revoke the credentials when done
+- name: Delete the lease
+  infisical.vault.delete_dynamic_secret_lease:
+    login_data: "{{ infisical_login.login_data }}"
+    project_slug: "my-project"
+    env_slug: "dev"
+    path: "/"
+    lease_id: "{{ lease.lease.id }}"
 ```

--- a/plugins/lookup/login.py
+++ b/plugins/lookup/login.py
@@ -100,4 +100,6 @@ class LookupModule(LookupBase):
             login_data = authenticator.login()
             return [login_data]
         except (ImportError, ValueError) as e:
-            raise AnsibleError(str(e))
+            raise AnsibleError(f"Configuration error during Infisical login: {e}")
+        except Exception as e:
+            raise AnsibleError(f"Failed to login to Infisical: {type(e).__name__}: {e}")

--- a/plugins/lookup/read_secrets.py
+++ b/plugins/lookup/read_secrets.py
@@ -197,7 +197,9 @@ class LookupModule(LookupBase):
             try:
                 return create_client_from_login_data(login_data)
             except (ImportError, ValueError) as e:
-                raise AnsibleError(str(e))
+                raise AnsibleError(f"Configuration error creating client from login_data: {e}")
+            except Exception as e:
+                raise AnsibleError(f"Failed to create client from login_data: {type(e).__name__}: {e}")
         
         # Otherwise, authenticate fresh
         authenticator = InfisicalAuthenticator(
@@ -213,7 +215,9 @@ class LookupModule(LookupBase):
         try:
             return authenticator.authenticate()
         except (ImportError, ValueError) as e:
-            raise AnsibleError(str(e))
+            raise AnsibleError(f"Configuration error during Infisical authentication: {e}")
+        except Exception as e:
+            raise AnsibleError(f"Failed to authenticate with Infisical: {type(e).__name__}: {e}")
 
     def run(self, terms, variables=None, **kwargs):
         self.set_options(var_options=variables, direct=kwargs)

--- a/plugins/modules/create_dynamic_secret.py
+++ b/plugins/modules/create_dynamic_secret.py
@@ -236,7 +236,7 @@ def run_module():
             dynamic_secret=dynamic_secret.to_dict(),
         )
     except Exception as e:
-        module.fail_json(msg=f"Error creating dynamic secret: {e}")
+        module.fail_json(msg=f"Error creating dynamic secret: {type(e).__name__}: {e}")
 
 
 def main():

--- a/plugins/modules/create_dynamic_secret.py
+++ b/plugins/modules/create_dynamic_secret.py
@@ -1,0 +1,248 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: create_dynamic_secret
+short_description: Create a dynamic secret in Infisical
+version_added: "1.2.0"
+author:
+  - Infisical Inc.
+description:
+  - Create a new dynamic secret configuration in Infisical.
+  - Dynamic secrets generate credentials on-demand with automatic expiration.
+  - Supports various providers like SQL databases, AWS, GCP, Azure, and more.
+extends_documentation_fragment:
+  - infisical.vault.auth
+
+options:
+  project_slug:
+    description: The slug of the project where the dynamic secret will be created.
+    type: str
+    required: true
+  env_slug:
+    description: The environment slug where the dynamic secret will be created.
+    type: str
+    required: true
+  path:
+    description: "The folder path where the dynamic secret will be created. For example: /services/backend"
+    type: str
+    default: "/"
+  name:
+    description: The name of the dynamic secret.
+    type: str
+    required: true
+  provider_type:
+    description:
+      - The type of dynamic secret provider.
+      - Examples include sql-database, aws-iam, gcp-iam, azure-entra-id, etc.
+    type: str
+    required: true
+  inputs:
+    description:
+      - The provider-specific configuration inputs.
+      - The structure varies depending on the provider type.
+      - Check the Infisical API documentation for the specific provider inputs: [Dynamic Secrets API Documentation](https://infisical.com/docs/api-reference/endpoints/dynamic-secrets/create#body-provider)
+    type: dict
+    required: true
+  default_ttl:
+    description:
+      - The default time to live for leases.
+      - Example values are "1h", "30m", "24h".
+    type: str
+    required: true
+  max_ttl:
+    description:
+      - The maximum time to live for leases.
+      - Example values are "24h", "7d".
+    type: str
+  metadata:
+    description:
+      - Optional list of metadata items with 'key' and 'value'.
+    type: list
+    elements: dict
+
+seealso:
+  - module: infisical.vault.login
+    description: Use the login module to authenticate once and reuse the session.
+  - module: infisical.vault.get_dynamic_secret
+    description: Get a dynamic secret by name.
+  - module: infisical.vault.update_dynamic_secret
+    description: Update an existing dynamic secret.
+  - module: infisical.vault.delete_dynamic_secret
+    description: Delete a dynamic secret.
+  - module: infisical.vault.create_dynamic_secret_lease
+    description: Create a lease to generate credentials.
+"""
+
+EXAMPLES = r"""
+# Create a PostgreSQL dynamic secret
+- name: Create a PostgreSQL dynamic secret
+  infisical.vault.create_dynamic_secret:
+    login_data: "{{ infisical_login.login_data }}"
+    project_slug: "my-project"
+    env_slug: "dev"
+    path: "/"
+    name: "postgres-dev"
+    provider_type: "sql-database"
+    inputs:
+      client: "postgres"
+      host: "localhost"
+      port: 5432
+      database: "mydb"
+      username: "admin"
+      password: "admin-password"
+    default_ttl: "1h"
+    max_ttl: "24h"
+  register: dynamic_secret
+"""
+
+RETURN = r"""
+dynamic_secret:
+  description: The created dynamic secret.
+  returned: success
+  type: dict
+  contains:
+    id:
+      description: The unique identifier of the dynamic secret.
+      type: str
+    name:
+      description: The name of the dynamic secret.
+      type: str
+    version:
+      description: The version number of the dynamic secret.
+      type: int
+    type:
+      description: The provider type.
+      type: str
+    folderId:
+      description: The folder ID where the dynamic secret is stored.
+      type: str
+    createdAt:
+      description: The creation timestamp.
+      type: str
+    updatedAt:
+      description: The last update timestamp.
+      type: str
+    defaultTTL:
+      description: The default TTL for leases.
+      type: str
+    maxTTL:
+      description: The maximum TTL for leases.
+      type: str
+    status:
+      description: The status of the dynamic secret.
+      type: str
+    statusDetails:
+      description: Details about the status.
+      type: str
+    metadata:
+      description: Metadata key-value pairs.
+      type: list
+    inputs:
+      description: The provider-specific configuration inputs.
+      type: dict
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.infisical.vault.plugins.module_utils._authenticator import (
+    InfisicalAuthenticator,
+    create_client_from_login_data,
+)
+
+
+def get_sdk_client(module, login_data=None):
+    """Get an authenticated Infisical SDK client."""
+    if login_data is not None:
+        try:
+            return create_client_from_login_data(login_data)
+        except (ImportError, ValueError) as e:
+            module.fail_json(msg=str(e))
+    
+    try:
+        authenticator = InfisicalAuthenticator(
+            url=module.params['url'],
+            auth_method=module.params['auth_method'],
+            client_id=module.params['universal_auth_client_id'],
+            client_secret=module.params['universal_auth_client_secret'],
+            identity_id=module.params['identity_id'],
+            jwt=module.params['jwt'],
+            token=module.params['token'],
+        )
+        return authenticator.authenticate()
+    except (ImportError, ValueError) as e:
+        module.fail_json(msg=str(e))
+
+
+def run_module():
+    module_args = dict(
+        login_data=dict(type='dict', no_log=True),
+        url=dict(type='str', default='https://app.infisical.com'),
+        auth_method=dict(
+            type='str',
+            default='universal_auth',
+            choices=['universal_auth', 'oidc_auth', 'token_auth']
+        ),
+        universal_auth_client_id=dict(type='str'),
+        universal_auth_client_secret=dict(type='str', no_log=True),
+        identity_id=dict(type='str'),
+        jwt=dict(type='str', no_log=True),
+        token=dict(type='str', no_log=True),
+        project_slug=dict(type='str', required=True),
+        env_slug=dict(type='str', required=True),
+        path=dict(type='str', default='/'),
+        name=dict(type='str', required=True),
+        provider_type=dict(type='str', required=True),
+        inputs=dict(type='dict', required=True, no_log=True),
+        default_ttl=dict(type='str', required=True),
+        max_ttl=dict(type='str'),
+        metadata=dict(type='list', elements='dict'),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    if module.check_mode:
+        module.exit_json(
+            changed=True,
+            dynamic_secret={'name': module.params['name'], 'type': module.params['provider_type']},
+        )
+
+    try:
+        login_data = module.params.get('login_data')
+        client = get_sdk_client(module, login_data=login_data)
+        
+        create_kwargs = dict(
+            name=module.params['name'],
+            provider_type=module.params['provider_type'],
+            inputs=module.params['inputs'],
+            default_ttl=module.params['default_ttl'],
+            max_ttl=module.params['max_ttl'],
+            project_slug=module.params['project_slug'],
+            environment_slug=module.params['env_slug'],
+            path=module.params['path'],
+        )
+        
+        if module.params.get('metadata') is not None:
+            create_kwargs['metadata'] = module.params['metadata']
+        
+        dynamic_secret = client.dynamic_secrets.create(**create_kwargs)
+        
+        module.exit_json(
+            changed=True,
+            dynamic_secret=dynamic_secret.to_dict(),
+        )
+    except Exception as e:
+        module.fail_json(msg=f"Error creating dynamic secret: {e}")
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()
+

--- a/plugins/modules/create_dynamic_secret_lease.py
+++ b/plugins/modules/create_dynamic_secret_lease.py
@@ -180,7 +180,7 @@ def run_module():
     if module.check_mode:
         module.exit_json(
             changed=True,
-            lease={'dynamicSecretName': module.params['dynamic_secret_name']},
+            lease={'id': 'check_mode_mock'},
             dynamic_secret={},
             data={},
         )
@@ -208,7 +208,7 @@ def run_module():
             data=result.data,
         )
     except Exception as e:
-        module.fail_json(msg=f"Error creating dynamic secret lease: {e}")
+        module.fail_json(msg=f"Error creating dynamic secret lease: {type(e).__name__}: {e}")
 
 
 def main():

--- a/plugins/modules/create_dynamic_secret_lease.py
+++ b/plugins/modules/create_dynamic_secret_lease.py
@@ -1,0 +1,220 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: create_dynamic_secret_lease
+short_description: Create a lease for a dynamic secret in Infisical
+version_added: "1.2.0"
+author:
+  - Infisical Inc.
+description:
+  - Create a new lease for a dynamic secret, which generates credentials.
+  - The credentials are returned in the data field and are valid until the lease expires.
+  - Use renew_dynamic_secret_lease to extend the lease, or delete_dynamic_secret_lease to revoke it.
+extends_documentation_fragment:
+  - infisical.vault.auth
+
+options:
+  project_slug:
+    description: The slug of the project containing the dynamic secret.
+    type: str
+    required: true
+  env_slug:
+    description: The environment slug where the dynamic secret is located.
+    type: str
+    required: true
+  path:
+    description: "The folder path where the dynamic secret is located. For example: /services/backend"
+    type: str
+    default: "/"
+  dynamic_secret_name:
+    description: The name of the dynamic secret to create a lease for.
+    type: str
+    required: true
+  ttl:
+    description:
+      - The time to live for the lease.
+      - Example values are "1h", "30m", "24h".
+      - If not specified, the default TTL from the dynamic secret will be used.
+    type: str
+
+seealso:
+  - module: infisical.vault.login
+    description: Use the login module to authenticate once and reuse the session.
+  - module: infisical.vault.get_dynamic_secret_lease
+    description: Get lease details.
+  - module: infisical.vault.renew_dynamic_secret_lease
+    description: Renew an existing lease.
+  - module: infisical.vault.delete_dynamic_secret_lease
+    description: Revoke a lease.
+"""
+
+EXAMPLES = r"""
+# Create a lease to get database credentials
+- name: Create a lease for PostgreSQL credentials
+  infisical.vault.create_dynamic_secret_lease:
+    login_data: "{{ infisical_login.login_data }}"
+    project_slug: "my-project"
+    env_slug: "dev"
+    path: "/"
+    dynamic_secret_name: "postgres-dev"
+    ttl: "1h"
+  register: lease
+
+- name: Display the generated credentials
+  debug:
+    msg: "Username: {{ lease.data.username }}, Password: {{ lease.data.password }}"
+
+- name: Use credentials with PostgreSQL
+  community.postgresql.postgresql_query:
+    login_host: localhost
+    login_user: "{{ lease.data.username }}"
+    login_password: "{{ lease.data.password }}"
+    db: mydb
+    query: "SELECT version();"
+"""
+
+RETURN = r"""
+lease:
+  description: The created lease information.
+  returned: success
+  type: dict
+  contains:
+    id:
+      description: The unique identifier of the lease.
+      type: str
+    expireAt:
+      description: The expiration timestamp of the lease.
+      type: str
+    createdAt:
+      description: The creation timestamp.
+      type: str
+    updatedAt:
+      description: The last update timestamp.
+      type: str
+    version:
+      description: The version number of the lease.
+      type: int
+    dynamicSecretId:
+      description: The ID of the dynamic secret this lease belongs to.
+      type: str
+    externalEntityId:
+      description: The external entity ID.
+      type: str
+    status:
+      description: The status of the lease.
+      type: str
+    statusDetails:
+      description: Details about the status.
+      type: str
+dynamic_secret:
+  description: The dynamic secret configuration.
+  returned: success
+  type: dict
+data:
+  description:
+    - The generated credentials.
+    - The structure depends on the dynamic secret provider.
+  returned: success
+  type: dict
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.infisical.vault.plugins.module_utils._authenticator import (
+    InfisicalAuthenticator,
+    create_client_from_login_data,
+)
+
+
+def get_sdk_client(module, login_data=None):
+    """Get an authenticated Infisical SDK client."""
+    if login_data is not None:
+        try:
+            return create_client_from_login_data(login_data)
+        except (ImportError, ValueError) as e:
+            module.fail_json(msg=str(e))
+    
+    try:
+        authenticator = InfisicalAuthenticator(
+            url=module.params['url'],
+            auth_method=module.params['auth_method'],
+            client_id=module.params['universal_auth_client_id'],
+            client_secret=module.params['universal_auth_client_secret'],
+            identity_id=module.params['identity_id'],
+            jwt=module.params['jwt'],
+            token=module.params['token'],
+        )
+        return authenticator.authenticate()
+    except (ImportError, ValueError) as e:
+        module.fail_json(msg=str(e))
+
+
+def run_module():
+    module_args = dict(
+        login_data=dict(type='dict', no_log=True),
+        url=dict(type='str', default='https://app.infisical.com'),
+        auth_method=dict(
+            type='str',
+            default='universal_auth',
+            choices=['universal_auth', 'oidc_auth', 'token_auth']
+        ),
+        universal_auth_client_id=dict(type='str'),
+        universal_auth_client_secret=dict(type='str', no_log=True),
+        identity_id=dict(type='str'),
+        jwt=dict(type='str', no_log=True),
+        token=dict(type='str', no_log=True),
+        project_slug=dict(type='str', required=True),
+        env_slug=dict(type='str', required=True),
+        path=dict(type='str', default='/'),
+        dynamic_secret_name=dict(type='str', required=True),
+        ttl=dict(type='str'),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    if module.check_mode:
+        module.exit_json(
+            changed=True,
+            lease={'dynamicSecretName': module.params['dynamic_secret_name']},
+            dynamic_secret={},
+            data={},
+        )
+
+    try:
+        login_data = module.params.get('login_data')
+        client = get_sdk_client(module, login_data=login_data)
+        
+        create_kwargs = dict(
+            dynamic_secret_name=module.params['dynamic_secret_name'],
+            project_slug=module.params['project_slug'],
+            environment_slug=module.params['env_slug'],
+            path=module.params['path'],
+        )
+        
+        if module.params.get('ttl') is not None:
+            create_kwargs['ttl'] = module.params['ttl']
+        
+        result = client.dynamic_secrets.leases.create(**create_kwargs)
+        
+        module.exit_json(
+            changed=True,
+            lease=result.lease.to_dict(),
+            dynamic_secret=result.dynamicSecret.to_dict(),
+            data=result.data,
+        )
+    except Exception as e:
+        module.fail_json(msg=f"Error creating dynamic secret lease: {e}")
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()
+

--- a/plugins/modules/create_dynamic_secret_lease.py
+++ b/plugins/modules/create_dynamic_secret_lease.py
@@ -64,13 +64,13 @@ EXAMPLES = r"""
 
 - name: Display the generated credentials
   debug:
-    msg: "Username: {{ lease.data.username }}, Password: {{ lease.data.password }}"
+    msg: "Username: {{ lease.data.DB_USERNAME }}, Password: {{ lease.data.DB_PASSWORD }}"
 
 - name: Use credentials with PostgreSQL
   community.postgresql.postgresql_query:
     login_host: localhost
-    login_user: "{{ lease.data.username }}"
-    login_password: "{{ lease.data.password }}"
+    login_user: "{{ lease.data.DB_USERNAME }}"
+    login_password: "{{ lease.data.DB_PASSWORD }}"
     db: mydb
     query: "SELECT version();"
 """

--- a/plugins/modules/create_secret.py
+++ b/plugins/modules/create_secret.py
@@ -271,7 +271,7 @@ def run_module():
             secret=clean_secret_dict(secret.to_dict()),
         )
     except Exception as e:
-        module.fail_json(msg=f"Error creating secret: {e}")
+        module.fail_json(msg=f"Error creating secret: {type(e).__name__}: {e}")
 
 
 def main():

--- a/plugins/modules/delete_dynamic_secret.py
+++ b/plugins/modules/delete_dynamic_secret.py
@@ -1,0 +1,206 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: delete_dynamic_secret
+short_description: Delete a dynamic secret from Infisical
+version_added: "1.2.0"
+author:
+  - Infisical Inc.
+description:
+  - Delete a dynamic secret configuration from Infisical.
+  - This will also revoke any active leases unless is_forced is used.
+extends_documentation_fragment:
+  - infisical.vault.auth
+
+options:
+  project_slug:
+    description: The slug of the project containing the dynamic secret.
+    type: str
+    required: true
+  env_slug:
+    description: The environment slug where the dynamic secret is located.
+    type: str
+    required: true
+  path:
+    description: "The folder path where the dynamic secret is located. For example: /services/backend"
+    type: str
+    default: "/"
+  name:
+    description: The name of the dynamic secret to delete.
+    type: str
+    required: true
+  is_forced:
+    description:
+      - A boolean flag to delete the dynamic secret from Infisical without trying to remove it from the external provider.
+      - Use this when the dynamic secret was modified externally.
+    type: bool
+    default: false
+
+seealso:
+  - module: infisical.vault.login
+    description: Use the login module to authenticate once and reuse the session.
+  - module: infisical.vault.create_dynamic_secret
+    description: Create a new dynamic secret.
+  - module: infisical.vault.get_dynamic_secret
+    description: Get a dynamic secret by name.
+"""
+
+EXAMPLES = r"""
+# Delete a dynamic secret
+- name: Delete a dynamic secret
+  infisical.vault.delete_dynamic_secret:
+    login_data: "{{ infisical_login.login_data }}"
+    project_slug: "my-project"
+    env_slug: "dev"
+    path: "/"
+    name: "postgres-dev"
+  register: deleted_secret
+
+# Force delete a dynamic secret
+- name: Force delete a dynamic secret
+  infisical.vault.delete_dynamic_secret:
+    login_data: "{{ infisical_login.login_data }}"
+    project_slug: "my-project"
+    env_slug: "dev"
+    path: "/"
+    name: "postgres-dev"
+    is_forced: true
+  register: deleted_secret
+"""
+
+RETURN = r"""
+dynamic_secret:
+  description: The deleted dynamic secret.
+  returned: success
+  type: dict
+  contains:
+    id:
+      description: The unique identifier of the dynamic secret.
+      type: str
+    name:
+      description: The name of the dynamic secret.
+      type: str
+    version:
+      description: The version number of the dynamic secret.
+      type: int
+    type:
+      description: The provider type.
+      type: str
+    folderId:
+      description: The folder ID where the dynamic secret was stored.
+      type: str
+    createdAt:
+      description: The creation timestamp.
+      type: str
+    updatedAt:
+      description: The last update timestamp.
+      type: str
+    defaultTTL:
+      description: The default TTL for leases.
+      type: str
+    maxTTL:
+      description: The maximum TTL for leases.
+      type: str
+    status:
+      description: The status of the dynamic secret.
+      type: str
+    statusDetails:
+      description: Details about the status.
+      type: str
+    metadata:
+      description: Metadata key-value pairs.
+      type: list
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.infisical.vault.plugins.module_utils._authenticator import (
+    InfisicalAuthenticator,
+    create_client_from_login_data,
+)
+
+
+def get_sdk_client(module, login_data=None):
+    """Get an authenticated Infisical SDK client."""
+    if login_data is not None:
+        try:
+            return create_client_from_login_data(login_data)
+        except (ImportError, ValueError) as e:
+            module.fail_json(msg=str(e))
+    
+    try:
+        authenticator = InfisicalAuthenticator(
+            url=module.params['url'],
+            auth_method=module.params['auth_method'],
+            client_id=module.params['universal_auth_client_id'],
+            client_secret=module.params['universal_auth_client_secret'],
+            identity_id=module.params['identity_id'],
+            jwt=module.params['jwt'],
+            token=module.params['token'],
+        )
+        return authenticator.authenticate()
+    except (ImportError, ValueError) as e:
+        module.fail_json(msg=str(e))
+
+
+def run_module():
+    module_args = dict(
+        login_data=dict(type='dict', no_log=True),
+        url=dict(type='str', default='https://app.infisical.com'),
+        auth_method=dict(
+            type='str',
+            default='universal_auth',
+            choices=['universal_auth', 'oidc_auth', 'token_auth']
+        ),
+        universal_auth_client_id=dict(type='str'),
+        universal_auth_client_secret=dict(type='str', no_log=True),
+        identity_id=dict(type='str'),
+        jwt=dict(type='str', no_log=True),
+        token=dict(type='str', no_log=True),
+        project_slug=dict(type='str', required=True),
+        env_slug=dict(type='str', required=True),
+        path=dict(type='str', default='/'),
+        name=dict(type='str', required=True),
+        is_forced=dict(type='bool', default=False),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    if module.check_mode:
+        module.exit_json(
+            changed=True,
+            dynamic_secret={'name': module.params['name']},
+        )
+
+    try:
+        login_data = module.params.get('login_data')
+        client = get_sdk_client(module, login_data=login_data)
+        
+        dynamic_secret = client.dynamic_secrets.delete(
+            name=module.params['name'],
+            project_slug=module.params['project_slug'],
+            environment_slug=module.params['env_slug'],
+            path=module.params['path'],
+            is_forced=module.params['is_forced'],
+        )
+        
+        module.exit_json(
+            changed=True,
+            dynamic_secret=dynamic_secret.to_dict(),
+        )
+    except Exception as e:
+        module.fail_json(msg=f"Error deleting dynamic secret: {e}")
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()
+

--- a/plugins/modules/delete_dynamic_secret.py
+++ b/plugins/modules/delete_dynamic_secret.py
@@ -194,7 +194,7 @@ def run_module():
             dynamic_secret=dynamic_secret.to_dict(),
         )
     except Exception as e:
-        module.fail_json(msg=f"Error deleting dynamic secret: {e}")
+        module.fail_json(msg=f"Error deleting dynamic secret: {type(e).__name__}: {e}")
 
 
 def main():

--- a/plugins/modules/delete_dynamic_secret_lease.py
+++ b/plugins/modules/delete_dynamic_secret_lease.py
@@ -174,7 +174,7 @@ def run_module():
         login_data = module.params.get('login_data')
         client = get_sdk_client(module, login_data=login_data)
         
-        lease = client.dynamic_secrets.leases.delete(
+        lease = client.dynamic_secrets.leases.revoke(
             lease_id=module.params['lease_id'],
             project_slug=module.params['project_slug'],
             environment_slug=module.params['env_slug'],

--- a/plugins/modules/delete_dynamic_secret_lease.py
+++ b/plugins/modules/delete_dynamic_secret_lease.py
@@ -1,0 +1,199 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: delete_dynamic_secret_lease
+short_description: Delete a dynamic secret lease from Infisical
+version_added: "1.2.0"
+author:
+  - Infisical Inc.
+description:
+  - Delete (revoke) a dynamic secret lease from Infisical.
+  - This will invalidate the credentials associated with the lease.
+extends_documentation_fragment:
+  - infisical.vault.auth
+
+options:
+  project_slug:
+    description: The slug of the project containing the dynamic secret.
+    type: str
+    required: true
+  env_slug:
+    description: The environment slug where the dynamic secret is located.
+    type: str
+    required: true
+  path:
+    description: "The folder path where the dynamic secret is located. For example: /services/backend"
+    type: str
+    default: "/"
+  lease_id:
+    description: The ID of the lease to delete.
+    type: str
+    required: true
+  is_forced:
+    description:
+      - A boolean flag to delete the lease from Infisical without trying to remove it from the external provider.
+      - Use this when the lease was modified externally.
+    type: bool
+    default: false
+
+seealso:
+  - module: infisical.vault.login
+    description: Use the login module to authenticate once and reuse the session.
+  - module: infisical.vault.create_dynamic_secret_lease
+    description: Create a new lease.
+  - module: infisical.vault.get_dynamic_secret_lease
+    description: Get lease details.
+  - module: infisical.vault.renew_dynamic_secret_lease
+    description: Renew an existing lease.
+"""
+
+EXAMPLES = r"""
+# Delete a lease
+- name: Delete a lease
+  infisical.vault.delete_dynamic_secret_lease:
+    login_data: "{{ infisical_login.login_data }}"
+    project_slug: "my-project"
+    env_slug: "dev"
+    path: "/"
+    lease_id: "{{ created_lease.lease.id }}"
+  register: deleted_lease
+
+# Force delete a lease
+- name: Force delete a lease
+  infisical.vault.delete_dynamic_secret_lease:
+    login_data: "{{ infisical_login.login_data }}"
+    project_slug: "my-project"
+    env_slug: "dev"
+    path: "/"
+    lease_id: "{{ created_lease.lease.id }}"
+    is_forced: true
+  register: deleted_lease
+"""
+
+RETURN = r"""
+lease:
+  description: The deleted lease information.
+  returned: success
+  type: dict
+  contains:
+    id:
+      description: The unique identifier of the lease.
+      type: str
+    expireAt:
+      description: The expiration timestamp of the lease.
+      type: str
+    createdAt:
+      description: The creation timestamp.
+      type: str
+    updatedAt:
+      description: The last update timestamp.
+      type: str
+    version:
+      description: The version number of the lease.
+      type: int
+    dynamicSecretId:
+      description: The ID of the dynamic secret this lease belongs to.
+      type: str
+    externalEntityId:
+      description: The external entity ID.
+      type: str
+    status:
+      description: The status of the lease.
+      type: str
+    statusDetails:
+      description: Details about the status.
+      type: str
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.infisical.vault.plugins.module_utils._authenticator import (
+    InfisicalAuthenticator,
+    create_client_from_login_data,
+)
+
+
+def get_sdk_client(module, login_data=None):
+    """Get an authenticated Infisical SDK client."""
+    if login_data is not None:
+        try:
+            return create_client_from_login_data(login_data)
+        except (ImportError, ValueError) as e:
+            module.fail_json(msg=str(e))
+    
+    try:
+        authenticator = InfisicalAuthenticator(
+            url=module.params['url'],
+            auth_method=module.params['auth_method'],
+            client_id=module.params['universal_auth_client_id'],
+            client_secret=module.params['universal_auth_client_secret'],
+            identity_id=module.params['identity_id'],
+            jwt=module.params['jwt'],
+            token=module.params['token'],
+        )
+        return authenticator.authenticate()
+    except (ImportError, ValueError) as e:
+        module.fail_json(msg=str(e))
+
+
+def run_module():
+    module_args = dict(
+        login_data=dict(type='dict', no_log=True),
+        url=dict(type='str', default='https://app.infisical.com'),
+        auth_method=dict(
+            type='str',
+            default='universal_auth',
+            choices=['universal_auth', 'oidc_auth', 'token_auth']
+        ),
+        universal_auth_client_id=dict(type='str'),
+        universal_auth_client_secret=dict(type='str', no_log=True),
+        identity_id=dict(type='str'),
+        jwt=dict(type='str', no_log=True),
+        token=dict(type='str', no_log=True),
+        project_slug=dict(type='str', required=True),
+        env_slug=dict(type='str', required=True),
+        path=dict(type='str', default='/'),
+        lease_id=dict(type='str', required=True),
+        is_forced=dict(type='bool', default=False),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    if module.check_mode:
+        module.exit_json(
+            changed=True,
+            lease={'id': module.params['lease_id']},
+        )
+
+    try:
+        login_data = module.params.get('login_data')
+        client = get_sdk_client(module, login_data=login_data)
+        
+        lease = client.dynamic_secrets.leases.delete(
+            lease_id=module.params['lease_id'],
+            project_slug=module.params['project_slug'],
+            environment_slug=module.params['env_slug'],
+            path=module.params['path'],
+            is_forced=module.params['is_forced'],
+        )
+        
+        module.exit_json(
+            changed=True,
+            lease=lease.to_dict(),
+        )
+    except Exception as e:
+        module.fail_json(msg=f"Error deleting dynamic secret lease: {e}")
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()
+

--- a/plugins/modules/delete_dynamic_secret_lease.py
+++ b/plugins/modules/delete_dynamic_secret_lease.py
@@ -187,7 +187,7 @@ def run_module():
             lease=lease.to_dict(),
         )
     except Exception as e:
-        module.fail_json(msg=f"Error deleting dynamic secret lease: {e}")
+        module.fail_json(msg=f"Error deleting dynamic secret lease: {type(e).__name__}: {e}")
 
 
 def main():

--- a/plugins/modules/delete_secret.py
+++ b/plugins/modules/delete_secret.py
@@ -219,7 +219,7 @@ def run_module():
             secret=clean_secret_dict(secret.to_dict()),
         )
     except Exception as e:
-        module.fail_json(msg=f"Error deleting secret: {e}")
+        module.fail_json(msg=f"Error deleting secret: {type(e).__name__}: {e}")
 
 
 def main():

--- a/plugins/modules/get_dynamic_secret.py
+++ b/plugins/modules/get_dynamic_secret.py
@@ -183,7 +183,7 @@ def run_module():
             dynamic_secret=dynamic_secret.to_dict(),
         )
     except Exception as e:
-        module.fail_json(msg=f"Error getting dynamic secret: {e}")
+        module.fail_json(msg=f"Error getting dynamic secret: {type(e).__name__}: {e}")
 
 
 def main():

--- a/plugins/modules/get_dynamic_secret.py
+++ b/plugins/modules/get_dynamic_secret.py
@@ -1,0 +1,195 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: get_dynamic_secret
+short_description: Get a dynamic secret from Infisical
+version_added: "1.2.0"
+author:
+  - Infisical Inc.
+description:
+  - Retrieve a dynamic secret configuration by name from Infisical.
+  - This returns the dynamic secret metadata, not the generated credentials.
+  - To generate credentials, use the create_dynamic_secret_lease module.
+extends_documentation_fragment:
+  - infisical.vault.auth
+
+options:
+  project_slug:
+    description: The slug of the project containing the dynamic secret.
+    type: str
+    required: true
+  env_slug:
+    description: The environment slug where the dynamic secret is located.
+    type: str
+    required: true
+  path:
+    description: "The folder path where the dynamic secret is located. For example: /services/backend"
+    type: str
+    default: "/"
+  name:
+    description: The name of the dynamic secret to retrieve.
+    type: str
+    required: true
+
+seealso:
+  - module: infisical.vault.login
+    description: Use the login module to authenticate once and reuse the session.
+  - module: infisical.vault.create_dynamic_secret
+    description: Create a new dynamic secret.
+  - module: infisical.vault.create_dynamic_secret_lease
+    description: Create a lease to generate credentials.
+"""
+
+EXAMPLES = r"""
+# Get a dynamic secret by name
+- name: Get a dynamic secret
+  infisical.vault.get_dynamic_secret:
+    login_data: "{{ infisical_login.login_data }}"
+    project_slug: "my-project"
+    env_slug: "dev"
+    path: "/"
+    name: "postgres-dev"
+  register: dynamic_secret
+
+- name: Display the dynamic secret
+  debug:
+    var: dynamic_secret.dynamic_secret
+"""
+
+RETURN = r"""
+dynamic_secret:
+  description: The dynamic secret configuration.
+  returned: success
+  type: dict
+  contains:
+    id:
+      description: The unique identifier of the dynamic secret.
+      type: str
+    name:
+      description: The name of the dynamic secret.
+      type: str
+    version:
+      description: The version number of the dynamic secret.
+      type: int
+    type:
+      description: The provider type.
+      type: str
+    folderId:
+      description: The folder ID where the dynamic secret is stored.
+      type: str
+    createdAt:
+      description: The creation timestamp.
+      type: str
+    updatedAt:
+      description: The last update timestamp.
+      type: str
+    defaultTTL:
+      description: The default TTL for leases.
+      type: str
+    maxTTL:
+      description: The maximum TTL for leases.
+      type: str
+    status:
+      description: The status of the dynamic secret.
+      type: str
+    statusDetails:
+      description: Details about the status.
+      type: str
+    metadata:
+      description: Metadata key-value pairs.
+      type: list
+    inputs:
+      description: The provider-specific configuration inputs.
+      type: dict
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.infisical.vault.plugins.module_utils._authenticator import (
+    InfisicalAuthenticator,
+    create_client_from_login_data,
+)
+
+
+def get_sdk_client(module, login_data=None):
+    """Get an authenticated Infisical SDK client."""
+    if login_data is not None:
+        try:
+            return create_client_from_login_data(login_data)
+        except (ImportError, ValueError) as e:
+            module.fail_json(msg=str(e))
+    
+    try:
+        authenticator = InfisicalAuthenticator(
+            url=module.params['url'],
+            auth_method=module.params['auth_method'],
+            client_id=module.params['universal_auth_client_id'],
+            client_secret=module.params['universal_auth_client_secret'],
+            identity_id=module.params['identity_id'],
+            jwt=module.params['jwt'],
+            token=module.params['token'],
+        )
+        return authenticator.authenticate()
+    except (ImportError, ValueError) as e:
+        module.fail_json(msg=str(e))
+
+
+def run_module():
+    module_args = dict(
+        login_data=dict(type='dict', no_log=True),
+        url=dict(type='str', default='https://app.infisical.com'),
+        auth_method=dict(
+            type='str',
+            default='universal_auth',
+            choices=['universal_auth', 'oidc_auth', 'token_auth']
+        ),
+        universal_auth_client_id=dict(type='str'),
+        universal_auth_client_secret=dict(type='str', no_log=True),
+        identity_id=dict(type='str'),
+        jwt=dict(type='str', no_log=True),
+        token=dict(type='str', no_log=True),
+        project_slug=dict(type='str', required=True),
+        env_slug=dict(type='str', required=True),
+        path=dict(type='str', default='/'),
+        name=dict(type='str', required=True),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    if module.check_mode:
+        module.exit_json(
+            changed=False,
+            dynamic_secret={'name': module.params['name']},
+        )
+
+    try:
+        login_data = module.params.get('login_data')
+        client = get_sdk_client(module, login_data=login_data)
+        
+        dynamic_secret = client.dynamic_secrets.get_by_name(
+            name=module.params['name'],
+            project_slug=module.params['project_slug'],
+            environment_slug=module.params['env_slug'],
+            path=module.params['path'],
+        )
+        
+        module.exit_json(
+            changed=False,
+            dynamic_secret=dynamic_secret.to_dict(),
+        )
+    except Exception as e:
+        module.fail_json(msg=f"Error getting dynamic secret: {e}")
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()
+

--- a/plugins/modules/get_dynamic_secret_lease.py
+++ b/plugins/modules/get_dynamic_secret_lease.py
@@ -175,7 +175,7 @@ def run_module():
             lease=lease.to_dict(),
         )
     except Exception as e:
-        module.fail_json(msg=f"Error getting dynamic secret lease: {e}")
+        module.fail_json(msg=f"Error getting dynamic secret lease: {type(e).__name__}: {e}")
 
 
 def main():

--- a/plugins/modules/get_dynamic_secret_lease.py
+++ b/plugins/modules/get_dynamic_secret_lease.py
@@ -1,0 +1,187 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: get_dynamic_secret_lease
+short_description: Get a dynamic secret lease from Infisical
+version_added: "1.2.0"
+author:
+  - Infisical Inc.
+description:
+  - Retrieve a dynamic secret lease by ID from Infisical.
+  - Returns the lease details including expiration time and associated dynamic secret.
+extends_documentation_fragment:
+  - infisical.vault.auth
+
+options:
+  project_slug:
+    description: The slug of the project containing the dynamic secret.
+    type: str
+    required: true
+  env_slug:
+    description: The environment slug where the dynamic secret is located.
+    type: str
+    required: true
+  path:
+    description: "The folder path where the dynamic secret is located. For example: /services/backend"
+    type: str
+    default: "/"
+  lease_id:
+    description: The ID of the lease to retrieve.
+    type: str
+    required: true
+
+seealso:
+  - module: infisical.vault.login
+    description: Use the login module to authenticate once and reuse the session.
+  - module: infisical.vault.create_dynamic_secret_lease
+    description: Create a new lease.
+  - module: infisical.vault.renew_dynamic_secret_lease
+    description: Renew an existing lease.
+  - module: infisical.vault.delete_dynamic_secret_lease
+    description: Revoke a lease.
+"""
+
+EXAMPLES = r"""
+# Get a lease by ID
+- name: Get lease details
+  infisical.vault.get_dynamic_secret_lease:
+    login_data: "{{ infisical_login.login_data }}"
+    project_slug: "my-project"
+    env_slug: "dev"
+    path: "/"
+    lease_id: "{{ created_lease.lease.id }}"
+  register: lease_details
+
+- name: Display lease expiration
+  debug:
+    msg: "Lease expires at: {{ lease_details.lease.expireAt }}"
+"""
+
+RETURN = r"""
+lease:
+  description: The lease information.
+  returned: success
+  type: dict
+  contains:
+    id:
+      description: The unique identifier of the lease.
+      type: str
+    expireAt:
+      description: The expiration timestamp of the lease.
+      type: str
+    createdAt:
+      description: The creation timestamp.
+      type: str
+    updatedAt:
+      description: The last update timestamp.
+      type: str
+    version:
+      description: The version number of the lease.
+      type: int
+    dynamicSecretId:
+      description: The ID of the dynamic secret this lease belongs to.
+      type: str
+    externalEntityId:
+      description: The external entity ID.
+      type: str
+    status:
+      description: The status of the lease.
+      type: str
+    statusDetails:
+      description: Details about the status.
+      type: str
+    dynamicSecret:
+      description: The associated dynamic secret configuration.
+      type: dict
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.infisical.vault.plugins.module_utils._authenticator import (
+    InfisicalAuthenticator,
+    create_client_from_login_data,
+)
+
+
+def get_sdk_client(module, login_data=None):
+    """Get an authenticated Infisical SDK client."""
+    if login_data is not None:
+        try:
+            return create_client_from_login_data(login_data)
+        except (ImportError, ValueError) as e:
+            module.fail_json(msg=str(e))
+    
+    try:
+        authenticator = InfisicalAuthenticator(
+            url=module.params['url'],
+            auth_method=module.params['auth_method'],
+            client_id=module.params['universal_auth_client_id'],
+            client_secret=module.params['universal_auth_client_secret'],
+            identity_id=module.params['identity_id'],
+            jwt=module.params['jwt'],
+            token=module.params['token'],
+        )
+        return authenticator.authenticate()
+    except (ImportError, ValueError) as e:
+        module.fail_json(msg=str(e))
+
+
+def run_module():
+    module_args = dict(
+        login_data=dict(type='dict', no_log=True),
+        url=dict(type='str', default='https://app.infisical.com'),
+        auth_method=dict(
+            type='str',
+            default='universal_auth',
+            choices=['universal_auth', 'oidc_auth', 'token_auth']
+        ),
+        universal_auth_client_id=dict(type='str'),
+        universal_auth_client_secret=dict(type='str', no_log=True),
+        identity_id=dict(type='str'),
+        jwt=dict(type='str', no_log=True),
+        token=dict(type='str', no_log=True),
+        project_slug=dict(type='str', required=True),
+        env_slug=dict(type='str', required=True),
+        path=dict(type='str', default='/'),
+        lease_id=dict(type='str', required=True),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    if module.check_mode:
+        module.exit_json(
+            changed=False,
+            lease={'id': module.params['lease_id']},
+        )
+
+    try:
+        login_data = module.params.get('login_data')
+        client = get_sdk_client(module, login_data=login_data)
+        
+        lease = client.dynamic_secrets.leases.get(
+            lease_id=module.params['lease_id'],
+            project_slug=module.params['project_slug'],
+            environment_slug=module.params['env_slug'],
+            path=module.params['path'],
+        )
+        
+        module.exit_json(
+            changed=False,
+            lease=lease.to_dict(),
+        )
+    except Exception as e:
+        module.fail_json(msg=f"Error getting dynamic secret lease: {e}")
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()
+

--- a/plugins/modules/login.py
+++ b/plugins/modules/login.py
@@ -131,7 +131,7 @@ def run_module():
     except (ImportError, ValueError) as e:
         module.fail_json(msg=str(e))
     except Exception as e:
-        module.fail_json(msg=f"Unexpected error during login: {e}")
+        module.fail_json(msg=f"Unexpected error during login: {type(e).__name__}: {e}")
 
 
 def main():

--- a/plugins/modules/read_secrets.py
+++ b/plugins/modules/read_secrets.py
@@ -335,7 +335,11 @@ def run_module():
             secrets=secrets,
         )
     except Exception as e:
-        module.fail_json(msg=f"Error fetching secrets: {e}")
+        import traceback
+        module.fail_json(
+            msg=f"Error fetching secrets: {type(e).__name__}: {e}",
+            exception=traceback.format_exc()
+        )
 
 
 def main():

--- a/plugins/modules/renew_dynamic_secret_lease.py
+++ b/plugins/modules/renew_dynamic_secret_lease.py
@@ -185,7 +185,7 @@ def run_module():
             lease=lease.to_dict(),
         )
     except Exception as e:
-        module.fail_json(msg=f"Error renewing dynamic secret lease: {e}")
+        module.fail_json(msg=f"Error renewing dynamic secret lease: {type(e).__name__}: {e}")
 
 
 def main():

--- a/plugins/modules/renew_dynamic_secret_lease.py
+++ b/plugins/modules/renew_dynamic_secret_lease.py
@@ -1,0 +1,197 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: renew_dynamic_secret_lease
+short_description: Renew a dynamic secret lease in Infisical
+version_added: "1.2.0"
+author:
+  - Infisical Inc.
+description:
+  - Renew an existing dynamic secret lease to extend its expiration time.
+  - The credentials associated with the lease remain valid.
+extends_documentation_fragment:
+  - infisical.vault.auth
+
+options:
+  project_slug:
+    description: The slug of the project containing the dynamic secret.
+    type: str
+    required: true
+  env_slug:
+    description: The environment slug where the dynamic secret is located.
+    type: str
+    required: true
+  path:
+    description: "The folder path where the dynamic secret is located. For example: /services/backend"
+    type: str
+    default: "/"
+  lease_id:
+    description: The ID of the lease to renew.
+    type: str
+    required: true
+  ttl:
+    description:
+      - The new time to live for the lease.
+      - Example values are "1h", "30m", "24h".
+      - Cannot exceed the max TTL of the dynamic secret.
+    type: str
+
+seealso:
+  - module: infisical.vault.login
+    description: Use the login module to authenticate once and reuse the session.
+  - module: infisical.vault.create_dynamic_secret_lease
+    description: Create a new lease.
+  - module: infisical.vault.get_dynamic_secret_lease
+    description: Get lease details.
+  - module: infisical.vault.delete_dynamic_secret_lease
+    description: Revoke a lease.
+"""
+
+EXAMPLES = r"""
+# Renew a lease
+- name: Renew a lease for 2 more hours
+  infisical.vault.renew_dynamic_secret_lease:
+    login_data: "{{ infisical_login.login_data }}"
+    project_slug: "my-project"
+    env_slug: "dev"
+    path: "/"
+    lease_id: "{{ created_lease.lease.id }}"
+    ttl: "2h"
+  register: renewed_lease
+
+- name: Display new expiration
+  debug:
+    msg: "Lease now expires at: {{ renewed_lease.lease.expireAt }}"
+"""
+
+RETURN = r"""
+lease:
+  description: The renewed lease information.
+  returned: success
+  type: dict
+  contains:
+    id:
+      description: The unique identifier of the lease.
+      type: str
+    expireAt:
+      description: The new expiration timestamp of the lease.
+      type: str
+    createdAt:
+      description: The creation timestamp.
+      type: str
+    updatedAt:
+      description: The last update timestamp.
+      type: str
+    version:
+      description: The version number of the lease.
+      type: int
+    dynamicSecretId:
+      description: The ID of the dynamic secret this lease belongs to.
+      type: str
+    externalEntityId:
+      description: The external entity ID.
+      type: str
+    status:
+      description: The status of the lease.
+      type: str
+    statusDetails:
+      description: Details about the status.
+      type: str
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.infisical.vault.plugins.module_utils._authenticator import (
+    InfisicalAuthenticator,
+    create_client_from_login_data,
+)
+
+
+def get_sdk_client(module, login_data=None):
+    """Get an authenticated Infisical SDK client."""
+    if login_data is not None:
+        try:
+            return create_client_from_login_data(login_data)
+        except (ImportError, ValueError) as e:
+            module.fail_json(msg=str(e))
+    
+    try:
+        authenticator = InfisicalAuthenticator(
+            url=module.params['url'],
+            auth_method=module.params['auth_method'],
+            client_id=module.params['universal_auth_client_id'],
+            client_secret=module.params['universal_auth_client_secret'],
+            identity_id=module.params['identity_id'],
+            jwt=module.params['jwt'],
+            token=module.params['token'],
+        )
+        return authenticator.authenticate()
+    except (ImportError, ValueError) as e:
+        module.fail_json(msg=str(e))
+
+
+def run_module():
+    module_args = dict(
+        login_data=dict(type='dict', no_log=True),
+        url=dict(type='str', default='https://app.infisical.com'),
+        auth_method=dict(
+            type='str',
+            default='universal_auth',
+            choices=['universal_auth', 'oidc_auth', 'token_auth']
+        ),
+        universal_auth_client_id=dict(type='str'),
+        universal_auth_client_secret=dict(type='str', no_log=True),
+        identity_id=dict(type='str'),
+        jwt=dict(type='str', no_log=True),
+        token=dict(type='str', no_log=True),
+        project_slug=dict(type='str', required=True),
+        env_slug=dict(type='str', required=True),
+        path=dict(type='str', default='/'),
+        lease_id=dict(type='str', required=True),
+        ttl=dict(type='str'),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    if module.check_mode:
+        module.exit_json(
+            changed=True,
+            lease={'id': module.params['lease_id']},
+        )
+
+    try:
+        login_data = module.params.get('login_data')
+        client = get_sdk_client(module, login_data=login_data)
+        
+        renew_kwargs = dict(
+            lease_id=module.params['lease_id'],
+            project_slug=module.params['project_slug'],
+            environment_slug=module.params['env_slug'],
+            path=module.params['path'],
+        )
+        
+        if module.params.get('ttl') is not None:
+            renew_kwargs['ttl'] = module.params['ttl']
+        
+        lease = client.dynamic_secrets.leases.renew(**renew_kwargs)
+        
+        module.exit_json(
+            changed=True,
+            lease=lease.to_dict(),
+        )
+    except Exception as e:
+        module.fail_json(msg=f"Error renewing dynamic secret lease: {e}")
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()
+

--- a/plugins/modules/update_dynamic_secret.py
+++ b/plugins/modules/update_dynamic_secret.py
@@ -1,0 +1,253 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: update_dynamic_secret
+short_description: Update a dynamic secret in Infisical
+version_added: "1.2.0"
+author:
+  - Infisical Inc.
+description:
+  - Update an existing dynamic secret configuration in Infisical.
+  - You can update the name, TTL settings, provider inputs, and metadata.
+extends_documentation_fragment:
+  - infisical.vault.auth
+
+options:
+  project_slug:
+    description: The slug of the project containing the dynamic secret.
+    type: str
+    required: true
+  env_slug:
+    description: The environment slug where the dynamic secret is located.
+    type: str
+    required: true
+  path:
+    description: "The folder path where the dynamic secret is located. For example: /services/backend"
+    type: str
+    default: "/"
+  name:
+    description: The current name of the dynamic secret to update.
+    type: str
+    required: true
+  new_name:
+    description: The new name for the dynamic secret (if renaming).
+    type: str
+  data:
+    description:
+      - The provider-specific configuration to update.
+      - This is required by the API but can be an empty dict if only updating other fields.
+    type: dict
+    required: true
+  inputs:
+    description:
+      - Updated provider inputs.
+      - The structure varies depending on the provider type.
+    type: dict
+  default_ttl:
+    description:
+      - The new default time to live for leases.
+      - Example values are "1h", "30m", "24h".
+    type: str
+  max_ttl:
+    description:
+      - The new maximum time to live for leases.
+      - Example values are "24h", "7d".
+    type: str
+  metadata:
+    description:
+      - Updated list of metadata items with 'key' and 'value'.
+    type: list
+    elements: dict
+
+seealso:
+  - module: infisical.vault.login
+    description: Use the login module to authenticate once and reuse the session.
+  - module: infisical.vault.get_dynamic_secret
+    description: Get a dynamic secret by name.
+  - module: infisical.vault.create_dynamic_secret
+    description: Create a new dynamic secret.
+  - module: infisical.vault.delete_dynamic_secret
+    description: Delete a dynamic secret.
+"""
+
+EXAMPLES = r"""
+# Update a dynamic secret's TTL
+- name: Update dynamic secret TTL
+  infisical.vault.update_dynamic_secret:
+    login_data: "{{ infisical_login.login_data }}"
+    project_slug: "my-project"
+    env_slug: "dev"
+    path: "/"
+    name: "postgres-dev"
+    data: {}
+    default_ttl: "2h"
+    max_ttl: "48h"
+  register: updated_secret
+
+# Rename a dynamic secret
+- name: Rename dynamic secret
+  infisical.vault.update_dynamic_secret:
+    login_data: "{{ infisical_login.login_data }}"
+    project_slug: "my-project"
+    env_slug: "dev"
+    path: "/"
+    name: "postgres-dev"
+    new_name: "postgres-development"
+    data: {}
+  register: renamed_secret
+"""
+
+RETURN = r"""
+dynamic_secret:
+  description: The updated dynamic secret.
+  returned: success
+  type: dict
+  contains:
+    id:
+      description: The unique identifier of the dynamic secret.
+      type: str
+    name:
+      description: The name of the dynamic secret.
+      type: str
+    version:
+      description: The version number of the dynamic secret.
+      type: int
+    type:
+      description: The provider type.
+      type: str
+    folderId:
+      description: The folder ID where the dynamic secret is stored.
+      type: str
+    createdAt:
+      description: The creation timestamp.
+      type: str
+    updatedAt:
+      description: The last update timestamp.
+      type: str
+    defaultTTL:
+      description: The default TTL for leases.
+      type: str
+    maxTTL:
+      description: The maximum TTL for leases.
+      type: str
+    status:
+      description: The status of the dynamic secret.
+      type: str
+    statusDetails:
+      description: Details about the status.
+      type: str
+    metadata:
+      description: Metadata key-value pairs.
+      type: list
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.infisical.vault.plugins.module_utils._authenticator import (
+    InfisicalAuthenticator,
+    create_client_from_login_data,
+)
+
+
+def get_sdk_client(module, login_data=None):
+    """Get an authenticated Infisical SDK client."""
+    if login_data is not None:
+        try:
+            return create_client_from_login_data(login_data)
+        except (ImportError, ValueError) as e:
+            module.fail_json(msg=str(e))
+    
+    try:
+        authenticator = InfisicalAuthenticator(
+            url=module.params['url'],
+            auth_method=module.params['auth_method'],
+            client_id=module.params['universal_auth_client_id'],
+            client_secret=module.params['universal_auth_client_secret'],
+            identity_id=module.params['identity_id'],
+            jwt=module.params['jwt'],
+            token=module.params['token'],
+        )
+        return authenticator.authenticate()
+    except (ImportError, ValueError) as e:
+        module.fail_json(msg=str(e))
+
+
+def run_module():
+    module_args = dict(
+        login_data=dict(type='dict', no_log=True),
+        url=dict(type='str', default='https://app.infisical.com'),
+        auth_method=dict(
+            type='str',
+            default='universal_auth',
+            choices=['universal_auth', 'oidc_auth', 'token_auth']
+        ),
+        universal_auth_client_id=dict(type='str'),
+        universal_auth_client_secret=dict(type='str', no_log=True),
+        identity_id=dict(type='str'),
+        jwt=dict(type='str', no_log=True),
+        token=dict(type='str', no_log=True),
+        project_slug=dict(type='str', required=True),
+        env_slug=dict(type='str', required=True),
+        path=dict(type='str', default='/'),
+        name=dict(type='str', required=True),
+        new_name=dict(type='str'),
+        data=dict(type='dict', required=True, no_log=True),
+        inputs=dict(type='dict', no_log=True),
+        default_ttl=dict(type='str'),
+        max_ttl=dict(type='str'),
+        metadata=dict(type='list', elements='dict'),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    if module.check_mode:
+        module.exit_json(
+            changed=True,
+            dynamic_secret={'name': module.params.get('new_name') or module.params['name']},
+        )
+
+    try:
+        login_data = module.params.get('login_data')
+        client = get_sdk_client(module, login_data=login_data)
+        
+        update_kwargs = dict(
+            name=module.params['name'],
+            project_slug=module.params['project_slug'],
+            environment_slug=module.params['env_slug'],
+            data=module.params['data'],
+            path=module.params['path'],
+        )
+        
+        if module.params.get('new_name') is not None:
+            update_kwargs['new_name'] = module.params['new_name']
+        if module.params.get('inputs') is not None:
+            update_kwargs['inputs'] = module.params['inputs']
+        if module.params.get('default_ttl') is not None:
+            update_kwargs['default_ttl'] = module.params['default_ttl']
+        if module.params.get('max_ttl') is not None:
+            update_kwargs['max_ttl'] = module.params['max_ttl']
+        if module.params.get('metadata') is not None:
+            update_kwargs['metadata'] = module.params['metadata']
+        
+        dynamic_secret = client.dynamic_secrets.update(**update_kwargs)
+        
+        module.exit_json(
+            changed=True,
+            dynamic_secret=dynamic_secret.to_dict(),
+        )
+    except Exception as e:
+        module.fail_json(msg=f"Error updating dynamic secret: {e}")
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()
+

--- a/plugins/modules/update_dynamic_secret.py
+++ b/plugins/modules/update_dynamic_secret.py
@@ -241,7 +241,7 @@ def run_module():
             dynamic_secret=dynamic_secret.to_dict(),
         )
     except Exception as e:
-        module.fail_json(msg=f"Error updating dynamic secret: {e}")
+        module.fail_json(msg=f"Error updating dynamic secret: {type(e).__name__}: {e}")
 
 
 def main():

--- a/plugins/modules/update_secret.py
+++ b/plugins/modules/update_secret.py
@@ -288,7 +288,7 @@ def run_module():
             secret=clean_secret_dict(secret.to_dict()),
         )
     except Exception as e:
-        module.fail_json(msg=f"Error updating secret: {e}")
+        module.fail_json(msg=f"Error updating secret: {type(e).__name__}: {e}")
 
 
 def main():


### PR DESCRIPTION
In draft and should only be merged after https://github.com/Infisical/ansible-collection/pull/16 and https://github.com/Infisical/python-sdk-official/pull/51 are merged

Follow up PR to https://github.com/Infisical/ansible-collection/pull/16

This one adds support to Dynamic Secrets and Dynamic Secret Leases.

- **`create_dynamic_secret`** - Create a dynamic secret
- **`get_dynamic_secret`** - Get a dynamic secret by name
- **`update_dynamic_secret`** - Update a dynamic secret
- **`delete_dynamic_secret`** - Delete a dynamic secret
- **`create_dynamic_secret_lease`** - Create a lease (generates credentials)
- **`get_dynamic_secret_lease`** - Get lease details
- **`renew_dynamic_secret_lease`** - Renew an existing lease
- **`delete_dynamic_secret_lease`** - Delete/revoke a lease