### PR TITLE
feat: add LDAP authentication support to Infisical Ansible Collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You can either call modules by their Fully Qualified Collection Name (FQCN), suc
 
 ## Authentication
 
-The Infisical Ansible Collection supports Universal Auth, OIDC, and Token Auth for authenticating against Infisical.
+The Infisical Ansible Collection supports Universal Auth, OIDC, Token Auth, and LDAP Auth for authenticating against Infisical.
 
 ### Login Plugin (Recommended)
 
@@ -121,6 +121,40 @@ Token Auth allows you to authenticate directly with an access token. This can be
 | -------------- | ------------------------- |
 | auth_method    | `INFISICAL_AUTH_METHOD`   |
 | token          | `INFISICAL_TOKEN`         |
+
+### LDAP Auth
+
+LDAP Auth allows you to authenticate using LDAP credentials. You'll need to provide the machine identity ID along with your LDAP username and password.
+
+> **Note:** LDAP Auth requires `infisicalsdk` version 1.0.16 or newer.
+
+| Parameter Name | Environment Variable Name   |
+| -------------- | --------------------------- |
+| auth_method    | `INFISICAL_AUTH_METHOD`     |
+| identity_id    | `INFISICAL_IDENTITY_ID`     |
+| ldap_username  | `INFISICAL_LDAP_USERNAME`   |
+| ldap_password  | `INFISICAL_LDAP_PASSWORD`   |
+
+**Example using LDAP Auth:**
+
+```yaml
+- name: Login with LDAP
+  infisical.vault.login:
+    url: "https://app.infisical.com"
+    auth_method: ldap_auth
+    identity_id: "{{ ldap_identity_id }}"
+    ldap_username: "{{ ldap_username }}"
+    ldap_password: "{{ ldap_password }}"
+  register: infisical_login
+
+- name: Read secrets using LDAP login
+  infisical.vault.read_secrets:
+    login_data: "{{ infisical_login.login_data }}"
+    project_id: "{{ project_id }}"
+    env_slug: "dev"
+    path: "/"
+  register: secrets
+```
 
 ## Available Plugins and Modules
 

--- a/plugins/doc_fragments/auth.py
+++ b/plugins/doc_fragments/auth.py
@@ -29,6 +29,7 @@ _AUTH_METHOD_MODULE = """
       - universal_auth
       - oidc_auth
       - token_auth
+      - ldap_auth
 """
 
 _AUTH_METHOD_LOOKUP = """
@@ -41,6 +42,7 @@ _AUTH_METHOD_LOOKUP = """
       - universal_auth
       - oidc_auth
       - token_auth
+      - ldap_auth
     env:
       - name: INFISICAL_AUTH_METHOD
 """
@@ -107,6 +109,16 @@ _TOKEN_AUTH_MODULE = """
     no_log: true
 """
 
+_LDAP_AUTH_MODULE = """
+  ldap_username:
+    description: The LDAP username used to authenticate (for ldap_auth).
+    type: str
+  ldap_password:
+    description: The LDAP password used to authenticate (for ldap_auth).
+    type: str
+    no_log: true
+"""
+
 _TOKEN_AUTH_LOOKUP = """
   token:
     description: >
@@ -116,6 +128,21 @@ _TOKEN_AUTH_LOOKUP = """
     type: string
     env:
       - name: INFISICAL_TOKEN
+"""
+
+_LDAP_AUTH_LOOKUP = """
+  ldap_username:
+    description: The LDAP username used to authenticate (for ldap_auth).
+    required: False
+    type: string
+    env:
+      - name: INFISICAL_LDAP_USERNAME
+  ldap_password:
+    description: The LDAP password used to authenticate (for ldap_auth).
+    required: False
+    type: string
+    env:
+      - name: INFISICAL_LDAP_PASSWORD
 """
 
 _LOGIN_DATA_MODULE = """
@@ -149,19 +176,20 @@ class ModuleDocFragment:
     # Authentication options for login module (no login_data option)
     LOGIN = r"""
 options:
-{url}{auth_method}{universal_auth}{oidc_auth}{token_auth}
+{url}{auth_method}{universal_auth}{oidc_auth}{token_auth}{ldap_auth}
 """.format(
         url=_URL_MODULE,
         auth_method=_AUTH_METHOD_MODULE,
         universal_auth=_UNIVERSAL_AUTH_MODULE,
         oidc_auth=_OIDC_AUTH_MODULE,
         token_auth=_TOKEN_AUTH_MODULE,
+        ldap_auth=_LDAP_AUTH_MODULE,
     )
 
     # Standard authentication options for modules (includes login_data)
     DOCUMENTATION = r"""
 options:
-{login_data}{url}{auth_method}{universal_auth}{oidc_auth}{token_auth}
+{login_data}{url}{auth_method}{universal_auth}{oidc_auth}{token_auth}{ldap_auth}
 {note}
 """.format(
         login_data=_LOGIN_DATA_MODULE,
@@ -170,13 +198,14 @@ options:
         universal_auth=_UNIVERSAL_AUTH_MODULE,
         oidc_auth=_OIDC_AUTH_MODULE,
         token_auth=_TOKEN_AUTH_MODULE,
+        ldap_auth=_LDAP_AUTH_MODULE,
         note=_LOGIN_DATA_NOTE,
     )
 
     # Authentication options for lookup plugins (with env vars, includes login_data)
     LOOKUP = r"""
 options:
-{login_data}{url}{auth_method}{universal_auth}{oidc_auth}{token_auth}
+{login_data}{url}{auth_method}{universal_auth}{oidc_auth}{token_auth}{ldap_auth}
 {note}
 """.format(
         login_data=_LOGIN_DATA_LOOKUP,
@@ -185,17 +214,19 @@ options:
         universal_auth=_UNIVERSAL_AUTH_LOOKUP,
         oidc_auth=_OIDC_AUTH_LOOKUP,
         token_auth=_TOKEN_AUTH_LOOKUP,
+        ldap_auth=_LDAP_AUTH_LOOKUP,
         note=_LOGIN_DATA_NOTE,
     )
 
     # Authentication options for login lookup (no login_data, with env vars)
     LOOKUP_LOGIN = r"""
 options:
-{url}{auth_method}{universal_auth}{oidc_auth}{token_auth}
+{url}{auth_method}{universal_auth}{oidc_auth}{token_auth}{ldap_auth}
 """.format(
         url=_URL_LOOKUP,
         auth_method=_AUTH_METHOD_LOOKUP,
         universal_auth=_UNIVERSAL_AUTH_LOOKUP,
         oidc_auth=_OIDC_AUTH_LOOKUP,
         token_auth=_TOKEN_AUTH_LOOKUP,
+        ldap_auth=_LDAP_AUTH_LOOKUP,
     )

--- a/plugins/lookup/login.py
+++ b/plugins/lookup/login.py
@@ -56,6 +56,11 @@ EXAMPLES = r"""
   set_fact:
     infisical_login: "{{ lookup('infisical.vault.login', auth_method='token_auth', token='<your-token>') }}"
 
+# Using LDAP authentication
+- name: Login with LDAP
+  set_fact:
+    infisical_login: "{{ lookup('infisical.vault.login', auth_method='ldap_auth', identity_id='<identity-id>', ldap_username='<ldap-user>', ldap_password='<ldap-pass>') }}"
+
 # Display login info (for debugging - avoid in production as it exposes the token)
 - name: Show login data structure
   debug:
@@ -94,6 +99,8 @@ class LookupModule(LookupBase):
             identity_id=self.get_option('identity_id'),
             jwt=self.get_option('jwt'),
             token=self.get_option('token'),
+            ldap_username=self.get_option('ldap_username'),
+            ldap_password=self.get_option('ldap_password'),
         )
         
         try:

--- a/plugins/modules/login.py
+++ b/plugins/modules/login.py
@@ -56,6 +56,15 @@ EXAMPLES = r"""
     auth_method: token_auth
     token: "{{ my_token }}"
   register: infisical_login
+
+# Login with LDAP auth
+- name: Login with LDAP
+  infisical.vault.login:
+    auth_method: ldap_auth
+    identity_id: "{{ identity_id }}"
+    ldap_username: "{{ ldap_user }}"
+    ldap_password: "{{ ldap_pass }}"
+  register: infisical_login
 """
 
 RETURN = r"""
@@ -86,13 +95,15 @@ def run_module():
         auth_method=dict(
             type='str',
             default='universal_auth',
-            choices=['universal_auth', 'oidc_auth', 'token_auth']
+            choices=['universal_auth', 'oidc_auth', 'token_auth', 'ldap_auth']
         ),
         universal_auth_client_id=dict(type='str'),
         universal_auth_client_secret=dict(type='str', no_log=True),
         identity_id=dict(type='str'),
         jwt=dict(type='str', no_log=True),
         token=dict(type='str', no_log=True),
+        ldap_username=dict(type='str'),
+        ldap_password=dict(type='str', no_log=True),
     )
 
     module = AnsibleModule(
@@ -120,6 +131,8 @@ def run_module():
             identity_id=module.params['identity_id'],
             jwt=module.params['jwt'],
             token=module.params['token'],
+            ldap_username=module.params['ldap_username'],
+            ldap_password=module.params['ldap_password'],
         )
         
         login_data = authenticator.login()


### PR DESCRIPTION
### Summary

Adds LDAP authentication to the Infisical Ansible collection, aligned with the [Infisical Python SDK LDAP auth](https://infisical.com/docs/sdks/languages/python#ldap-auth) and [PR #55](https://github.com/Infisical/python-sdk-official/pull/55).

### Changes

- **Authenticator** (`_authenticator.py`): Added `ldap_auth` method using `identity_id`, `ldap_username`, and `ldap_password`. Requires `infisicalsdk` >= 1.0.16.
- **Login module** (`login.py`): New `ldap_auth` choice and parameters `ldap_username`, `ldap_password`.
- **Login lookup** (`login.py`): LDAP support and example usage.
- **Auth doc fragment** (`auth.py`): LDAP options for modules and lookups, including env vars `INFISICAL_LDAP_USERNAME` and `INFISICAL_LDAP_PASSWORD`.
- **README**: LDAP auth section with parameters, env vars, and usage example.

### Usage

```yaml
- name: Login with LDAP
  infisical.vault.login:
    auth_method: ldap_auth
    identity_id: "{{ ldap_identity_id }}"
    ldap_username: "{{ ldap_username }}"
    ldap_password: "{{ ldap_password }}"
  register: infisical_login
```