### PR TITLE
 feat: add folder management modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ LDAP Auth allows you to authenticate using LDAP credentials. You'll need to prov
 ### Lookups
 - `infisical.vault.login` - Authenticate and return reusable login data
 - `infisical.vault.read_secrets` - Read secrets from Infisical
+- `infisical.vault.list_folders` - List folders (directories) in Infisical
 
 ### Modules
 
@@ -170,6 +171,10 @@ LDAP Auth allows you to authenticate using LDAP credentials. You'll need to prov
 - `infisical.vault.create_secret` - Create a new secret
 - `infisical.vault.update_secret` - Update an existing secret
 - `infisical.vault.delete_secret` - Delete a secret
+
+**Folders:**
+- `infisical.vault.create_folder` - Create a folder
+- `infisical.vault.list_folders` - List folders at a given path (optionally recursive)
 
 **Dynamic Secrets:**
 - `infisical.vault.create_dynamic_secret` - Create a dynamic secret
@@ -245,6 +250,56 @@ LDAP Auth allows you to authenticate using LDAP credentials. You'll need to prov
     path: "/"
     secret_name: "API_KEY"
 ```
+
+### Managing Folders
+
+Folders organize secrets into hierarchical paths.
+
+```yaml
+# Create a top-level folder
+- name: Create services folder
+  infisical.vault.create_folder:
+    login_data: "{{ infisical_login.login_data }}"
+    project_id: "{{ project_id }}"
+    env_slug: "dev"
+    path: "/"
+    name: "services"
+
+# Create a nested folder
+- name: Create backend folder under /services
+  infisical.vault.create_folder:
+    login_data: "{{ infisical_login.login_data }}"
+    project_id: "{{ project_id }}"
+    env_slug: "dev"
+    path: "/services"
+    name: "backend"
+    description: "Secrets for the backend service"
+
+# List folders at a path
+- name: List folders at root
+  infisical.vault.list_folders:
+    login_data: "{{ infisical_login.login_data }}"
+    project_id: "{{ project_id }}"
+    env_slug: "dev"
+    path: "/"
+  register: result
+
+- name: Show folder names
+  debug:
+    msg: "{{ result.folders | map(attribute='name') | list }}"
+
+# Recursive listing
+- name: List all folders under /services
+  infisical.vault.list_folders:
+    login_data: "{{ infisical_login.login_data }}"
+    project_id: "{{ project_id }}"
+    env_slug: "dev"
+    path: "/services"
+    recursive: true
+  register: result
+```
+
+> **Note:** The Infisical Python SDK does not currently expose folder update or delete operations, so the collection does not provide those modules yet.
 
 ### Dynamic Secrets
 

--- a/plugins/lookup/list_folders.py
+++ b/plugins/lookup/list_folders.py
@@ -1,0 +1,159 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible.errors import AnsibleError
+from ansible.plugins.lookup import LookupBase
+
+from ansible_collections.infisical.vault.plugins.module_utils._authenticator import (
+    InfisicalAuthenticator,
+    create_client_from_login_data,
+)
+
+
+DOCUMENTATION = r"""
+name: list_folders
+author:
+  - Infisical Inc.
+version_added: "1.2.0"
+
+short_description: List folders (directories) stored in Infisical
+description:
+  - Retrieve the list of folders at a given path within a project and environment.
+  - Optionally walks the folder tree recursively.
+  - You can either provide authentication credentials directly, or use C(login_data) from a previous C(infisical.vault.login) lookup to reuse an authenticated session.
+extends_documentation_fragment:
+  - infisical.vault.auth.lookup
+
+seealso:
+  - ref: infisical.vault.login lookup
+    description: Use the login lookup to authenticate once and reuse the session.
+
+options:
+  path:
+    description: "The folder path to list folders under. For example: /services"
+    required: False
+    type: string
+    default: "/"
+  env_slug:
+    description: "The environment slug to list folders from. Environment slug is the short name of a given environment."
+    required: True
+    type: string
+  project_id:
+    description: "The ID of the project where folders are stored."
+    required: True
+    type: string
+  recursive:
+    description: Whether to list folders recursively under the given path.
+    required: False
+    type: bool
+    default: False
+"""
+
+EXAMPLES = r"""
+# List folders using a cached login
+- name: Login to Infisical once
+  set_fact:
+    infisical_login: "{{ lookup('infisical.vault.login', url='https://app.infisical.com', auth_method='universal_auth', universal_auth_client_id='<client-id>', universal_auth_client_secret='<client-secret>') }}"
+
+- name: List folders at /
+  set_fact:
+    folders: "{{ lookup('infisical.vault.list_folders', login_data=infisical_login, project_id='<project-id>', env_slug='dev', path='/') }}"
+
+- name: List folders recursively under /services
+  set_fact:
+    nested: "{{ lookup('infisical.vault.list_folders', login_data=infisical_login, project_id='<project-id>', env_slug='prod', path='/services', recursive=true) }}"
+"""
+
+RETURN = r"""
+_list:
+  description: A list of folder objects at the requested path.
+  type: list
+  elements: dict
+  contains:
+    id:
+      description: The unique identifier of the folder.
+      type: str
+    name:
+      description: The name of the folder.
+      type: str
+    envId:
+      description: The ID of the environment the folder belongs to.
+      type: str
+    parentId:
+      description: The ID of the parent folder.
+      type: str
+    version:
+      description: The version number of the folder.
+      type: int
+    description:
+      description: The folder description.
+      type: str
+    isReserved:
+      description: Whether the folder is reserved by Infisical.
+      type: bool
+    relativePath:
+      description: The relative path to the folder (when recursive listing).
+      type: str
+    createdAt:
+      description: The creation timestamp.
+      type: str
+    updatedAt:
+      description: The last update timestamp.
+      type: str
+    lastSecretModified:
+      description: Timestamp when a secret in this folder was last modified.
+      type: str
+"""
+
+
+class LookupModule(LookupBase):
+
+    def _get_sdk_client(self, login_data=None):
+        if login_data is not None:
+            try:
+                return create_client_from_login_data(login_data)
+            except (ImportError, ValueError) as e:
+                raise AnsibleError(f"Configuration error creating client from login_data: {e}")
+            except Exception as e:
+                raise AnsibleError(f"Failed to create client from login_data: {type(e).__name__}: {e}")
+
+        authenticator = InfisicalAuthenticator(
+            url=self.get_option('url'),
+            auth_method=self.get_option('auth_method'),
+            client_id=self.get_option('universal_auth_client_id'),
+            client_secret=self.get_option('universal_auth_client_secret'),
+            identity_id=self.get_option('identity_id'),
+            jwt=self.get_option('jwt'),
+            token=self.get_option('token'),
+            ldap_username=self.get_option('ldap_username'),
+            ldap_password=self.get_option('ldap_password'),
+        )
+
+        try:
+            return authenticator.authenticate()
+        except (ImportError, ValueError) as e:
+            raise AnsibleError(f"Configuration error during Infisical authentication: {e}")
+        except Exception as e:
+            raise AnsibleError(f"Failed to authenticate with Infisical: {type(e).__name__}: {e}")
+
+    def run(self, terms, variables=None, **kwargs):
+        self.set_options(var_options=variables, direct=kwargs)
+
+        login_data = kwargs.get('login_data')
+        client = self._get_sdk_client(login_data=login_data)
+
+        project_id = kwargs.get('project_id')
+        env_slug = kwargs.get('env_slug')
+        path = kwargs.get('path', '/')
+        recursive = kwargs.get('recursive', False)
+
+        try:
+            response = client.folders.list_folders(
+                project_id=project_id,
+                environment_slug=env_slug,
+                path=path,
+                recursive=recursive,
+            )
+            return [f.to_dict() for f in response.folders]
+        except Exception as e:
+            raise AnsibleError(f"Error listing folders: {type(e).__name__}: {e}")

--- a/plugins/module_utils/_authenticator.py
+++ b/plugins/module_utils/_authenticator.py
@@ -7,6 +7,11 @@ plugins and modules. It uses the Infisical Python SDK for all operations.
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+try:
+    from urllib.parse import urlparse
+except ImportError:  # Python 2 fallback (collection targets py3, kept for safety)
+    from urlparse import urlparse
+
 # Authentication method constants
 AUTH_METHOD_UNIVERSAL_AUTH = "universal_auth"
 AUTH_METHOD_OIDC_AUTH = "oidc_auth"
@@ -83,6 +88,39 @@ def check_minimum_version(current_version, minimum_version):
     return current_tuple >= minimum_tuple
 
 
+def validate_instance_url(url):
+    """Validate the Infisical instance URL before handing it to the SDK.
+
+    The SDK passes the host straight to an HTTP client, so an unvalidated value
+    (e.g. supplied via extra-vars or inventory in a shared AWX/Tower setup) could
+    point the controller at an internal service. Restricting the scheme to
+    http/https and requiring a hostname is a cheap guard against accidental or
+    malicious SSRF-style targets such as ``file://`` or scheme-less values.
+
+    Args:
+        url: The Infisical instance URL.
+
+    Returns:
+        The validated URL unchanged.
+
+    Raises:
+        ValueError: If the URL is empty, not a string, or not a valid http(s) URL.
+    """
+    if not url or not isinstance(url, str):
+        raise ValueError("Infisical instance 'url' must be a non-empty string.")
+
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(
+            f"Invalid Infisical instance 'url' scheme {parsed.scheme!r}: "
+            "only 'http' and 'https' are supported."
+        )
+    if not parsed.netloc:
+        raise ValueError(f"Invalid Infisical instance 'url' {url!r}: missing hostname.")
+
+    return url
+
+
 def create_client_from_login_data(login_data):
     """Create an authenticated SDK client from login data.
     
@@ -114,7 +152,9 @@ def create_client_from_login_data(login_data):
     
     if not url or not access_token:
         raise ValueError("login_data must contain 'url' and 'access_token' keys.")
-    
+
+    validate_instance_url(url)
+
     # Create a new client and authenticate with the saved token
     client = InfisicalSDKClient(host=url)
     client.auth.token_auth.login(access_token)
@@ -215,7 +255,8 @@ class InfisicalAuthenticator:
             )
         
         self._validate()
-        
+        validate_instance_url(self.url)
+
         client = InfisicalSDKClient(host=self.url)
         
         # Perform authentication and capture the access token

--- a/plugins/modules/create_folder.py
+++ b/plugins/modules/create_folder.py
@@ -187,12 +187,6 @@ def run_module():
         supports_check_mode=True,
     )
 
-    if module.check_mode:
-        module.exit_json(
-            changed=True,
-            folder={'name': module.params['name'], 'path': module.params['path']},
-        )
-
     try:
         login_data = module.params.get('login_data')
         client = get_sdk_client(module, login_data=login_data)
@@ -201,6 +195,9 @@ def run_module():
         parent_path = module.params['path']
         requested_description = module.params.get('description')
 
+        # Listing folders is a read-only operation, so it runs in check mode too.
+        # This keeps the dry-run result accurate: an already-existing folder is
+        # reported as changed=False, matching what a real run would do.
         listing = client.folders.list_folders(
             project_id=module.params['project_id'],
             environment_slug=module.params['env_slug'],
@@ -221,13 +218,23 @@ def run_module():
                 )
             module.exit_json(changed=False, folder=existing_dict)
 
-        folder = client.folders.create_folder(
+        # Creating the folder is the only mutating operation; skip it in check mode.
+        if module.check_mode:
+            module.exit_json(
+                changed=True,
+                folder={'name': name, 'path': parent_path},
+            )
+
+        create_kwargs = dict(
             name=name,
             environment_slug=module.params['env_slug'],
             project_id=module.params['project_id'],
             path=parent_path,
-            description=requested_description,
         )
+        if requested_description is not None:
+            create_kwargs['description'] = requested_description
+
+        folder = client.folders.create_folder(**create_kwargs)
 
         module.exit_json(
             changed=True,

--- a/plugins/modules/create_folder.py
+++ b/plugins/modules/create_folder.py
@@ -1,0 +1,216 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: create_folder
+short_description: Create a folder (directory) in Infisical
+version_added: "1.2.0"
+author:
+  - Infisical Inc.
+description:
+  - Create a new folder in Infisical at the specified path within a given project and environment.
+  - Folders are used to organize secrets into hierarchical directories.
+extends_documentation_fragment:
+  - infisical.vault.auth
+
+options:
+  project_id:
+    description: The ID of the project where the folder will be created.
+    type: str
+    required: true
+  env_slug:
+    description: >
+      The environment slug where the folder will be created.
+      Environment slug is the short name of a given environment.
+    type: str
+    required: true
+  path:
+    description: "The parent folder path where the new folder will be created. For example: /services/backend"
+    type: str
+    default: "/"
+  name:
+    description: The name of the folder to create.
+    type: str
+    required: true
+  description:
+    description: An optional description for the folder.
+    type: str
+
+seealso:
+  - module: infisical.vault.login
+    description: Use the login module to authenticate once and reuse the session.
+  - module: infisical.vault.list_folders
+    description: List folders at a given path.
+  - module: infisical.vault.create_secret
+    description: Create a secret inside a folder.
+"""
+
+EXAMPLES = r"""
+# Create a folder with direct authentication
+- name: Create a folder
+  infisical.vault.create_folder:
+    url: "https://app.infisical.com"
+    auth_method: universal_auth
+    universal_auth_client_id: "{{ client_id }}"
+    universal_auth_client_secret: "{{ client_secret }}"
+    project_id: "my-project-id"
+    env_slug: "dev"
+    path: "/"
+    name: "services"
+  register: created_folder
+
+# Create a nested folder using login_data
+- name: Login to Infisical
+  infisical.vault.login:
+    url: "https://app.infisical.com"
+    auth_method: universal_auth
+    universal_auth_client_id: "{{ client_id }}"
+    universal_auth_client_secret: "{{ client_secret }}"
+  register: infisical_login
+
+- name: Create a backend folder under /services
+  infisical.vault.create_folder:
+    login_data: "{{ infisical_login.login_data }}"
+    project_id: "my-project-id"
+    env_slug: "prod"
+    path: "/services"
+    name: "backend"
+    description: "Secrets for the backend service"
+  register: created_folder
+"""
+
+RETURN = r"""
+folder:
+  description: The created folder.
+  returned: success
+  type: dict
+  contains:
+    id:
+      description: The unique identifier of the folder.
+      type: str
+    name:
+      description: The name of the folder.
+      type: str
+    path:
+      description: The parent path where the folder was created.
+      type: str
+    envId:
+      description: The ID of the environment the folder belongs to.
+      type: str
+    parentId:
+      description: The ID of the parent folder.
+      type: str
+    version:
+      description: The version number of the folder.
+      type: int
+    description:
+      description: The folder description.
+      type: str
+    isReserved:
+      description: Whether the folder is reserved by Infisical.
+      type: bool
+    createdAt:
+      description: The creation timestamp.
+      type: str
+    updatedAt:
+      description: The last update timestamp.
+      type: str
+    lastSecretModified:
+      description: Timestamp when a secret in this folder was last modified.
+      type: str
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.infisical.vault.plugins.module_utils._authenticator import (
+    InfisicalAuthenticator,
+    create_client_from_login_data,
+)
+
+
+def get_sdk_client(module, login_data=None):
+    """Get an authenticated Infisical SDK client."""
+    if login_data is not None:
+        try:
+            return create_client_from_login_data(login_data)
+        except (ImportError, ValueError) as e:
+            module.fail_json(msg=str(e))
+
+    try:
+        authenticator = InfisicalAuthenticator(
+            url=module.params['url'],
+            auth_method=module.params['auth_method'],
+            client_id=module.params['universal_auth_client_id'],
+            client_secret=module.params['universal_auth_client_secret'],
+            identity_id=module.params['identity_id'],
+            jwt=module.params['jwt'],
+            token=module.params['token'],
+            ldap_username=module.params['ldap_username'],
+            ldap_password=module.params['ldap_password'],
+        )
+        return authenticator.authenticate()
+    except (ImportError, ValueError) as e:
+        module.fail_json(msg=str(e))
+
+
+def run_module():
+    module_args = dict(
+        login_data=dict(type='dict', no_log=True),
+        url=dict(type='str', default='https://app.infisical.com'),
+        auth_method=dict(
+            type='str',
+            default='universal_auth',
+            choices=['universal_auth', 'oidc_auth', 'token_auth', 'ldap_auth']
+        ),
+        universal_auth_client_id=dict(type='str'),
+        universal_auth_client_secret=dict(type='str', no_log=True),
+        identity_id=dict(type='str'),
+        jwt=dict(type='str', no_log=True),
+        token=dict(type='str', no_log=True),
+        ldap_username=dict(type='str'),
+        ldap_password=dict(type='str', no_log=True),
+        project_id=dict(type='str', required=True),
+        env_slug=dict(type='str', required=True),
+        path=dict(type='str', default='/'),
+        name=dict(type='str', required=True),
+        description=dict(type='str'),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    if module.check_mode:
+        module.exit_json(
+            changed=True,
+            folder={'name': module.params['name'], 'path': module.params['path']},
+        )
+
+    try:
+        login_data = module.params.get('login_data')
+        client = get_sdk_client(module, login_data=login_data)
+
+        folder = client.folders.create_folder(
+            name=module.params['name'],
+            environment_slug=module.params['env_slug'],
+            project_id=module.params['project_id'],
+            path=module.params['path'],
+            description=module.params.get('description'),
+        )
+
+        module.exit_json(
+            changed=True,
+            folder=folder.to_dict(),
+        )
+    except Exception as e:
+        module.fail_json(msg=f"Error creating folder: {type(e).__name__}: {e}")
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/create_folder.py
+++ b/plugins/modules/create_folder.py
@@ -11,6 +11,11 @@ author:
 description:
   - Create a new folder in Infisical at the specified path within a given project and environment.
   - Folders are used to organize secrets into hierarchical directories.
+  - The module is idempotent. If a folder with the same name already exists at the parent
+    path, the existing folder is returned with C(changed=False). When the existing folder's
+    C(description) differs from the requested one, a warning is emitted because the Infisical
+    Python SDK does not currently support updating folders.
+  - Requires permission to list folders at the parent C(path) for the idempotency check.
 extends_documentation_fragment:
   - infisical.vault.auth
 
@@ -192,12 +197,36 @@ def run_module():
         login_data = module.params.get('login_data')
         client = get_sdk_client(module, login_data=login_data)
 
+        name = module.params['name']
+        parent_path = module.params['path']
+        requested_description = module.params.get('description')
+
+        listing = client.folders.list_folders(
+            project_id=module.params['project_id'],
+            environment_slug=module.params['env_slug'],
+            path=parent_path,
+            recursive=False,
+        )
+
+        existing = next((f for f in listing.folders if f.name == name), None)
+
+        if existing is not None:
+            existing_dict = existing.to_dict()
+            if requested_description is not None and existing_dict.get('description') != requested_description:
+                module.warn(
+                    f"Folder '{name}' at '{parent_path}' already exists with description "
+                    f"{existing_dict.get('description')!r}, but the requested description is "
+                    f"{requested_description!r}. The Infisical SDK does not support folder "
+                    f"updates, so the description was not changed."
+                )
+            module.exit_json(changed=False, folder=existing_dict)
+
         folder = client.folders.create_folder(
-            name=module.params['name'],
+            name=name,
             environment_slug=module.params['env_slug'],
             project_id=module.params['project_id'],
-            path=module.params['path'],
-            description=module.params.get('description'),
+            path=parent_path,
+            description=requested_description,
         )
 
         module.exit_json(

--- a/plugins/modules/list_folders.py
+++ b/plugins/modules/list_folders.py
@@ -1,0 +1,200 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: list_folders
+short_description: List folders (directories) in Infisical
+version_added: "1.2.0"
+author:
+  - Infisical Inc.
+description:
+  - List folders at the specified path within a given project and environment.
+  - Optionally walks the folder tree recursively.
+extends_documentation_fragment:
+  - infisical.vault.auth
+
+options:
+  project_id:
+    description: The ID of the project to list folders from.
+    type: str
+    required: true
+  env_slug:
+    description: >
+      The environment slug to list folders from.
+      Environment slug is the short name of a given environment.
+    type: str
+    required: true
+  path:
+    description: "The folder path to list folders under. For example: /services"
+    type: str
+    default: "/"
+  recursive:
+    description: Whether to list folders recursively under the given path.
+    type: bool
+    default: false
+
+seealso:
+  - module: infisical.vault.login
+    description: Use the login module to authenticate once and reuse the session.
+  - module: infisical.vault.create_folder
+    description: Create a new folder.
+  - module: infisical.vault.read_secrets
+    description: Read secrets from a folder.
+"""
+
+EXAMPLES = r"""
+# List top-level folders
+- name: List folders at root
+  infisical.vault.list_folders:
+    login_data: "{{ infisical_login.login_data }}"
+    project_id: "my-project-id"
+    env_slug: "dev"
+    path: "/"
+  register: result
+
+- name: Show folder names
+  debug:
+    msg: "{{ result.folders | map(attribute='name') | list }}"
+
+# Recursive listing under /services
+- name: List all folders under /services recursively
+  infisical.vault.list_folders:
+    login_data: "{{ infisical_login.login_data }}"
+    project_id: "my-project-id"
+    env_slug: "prod"
+    path: "/services"
+    recursive: true
+  register: result
+"""
+
+RETURN = r"""
+folders:
+  description: The list of folders at the specified path.
+  returned: success
+  type: list
+  elements: dict
+  contains:
+    id:
+      description: The unique identifier of the folder.
+      type: str
+    name:
+      description: The name of the folder.
+      type: str
+    envId:
+      description: The ID of the environment the folder belongs to.
+      type: str
+    parentId:
+      description: The ID of the parent folder.
+      type: str
+    version:
+      description: The version number of the folder.
+      type: int
+    description:
+      description: The folder description.
+      type: str
+    isReserved:
+      description: Whether the folder is reserved by Infisical.
+      type: bool
+    relativePath:
+      description: The relative path to the folder (when recursive listing).
+      type: str
+    createdAt:
+      description: The creation timestamp.
+      type: str
+    updatedAt:
+      description: The last update timestamp.
+      type: str
+    lastSecretModified:
+      description: Timestamp when a secret in this folder was last modified.
+      type: str
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.infisical.vault.plugins.module_utils._authenticator import (
+    InfisicalAuthenticator,
+    create_client_from_login_data,
+)
+
+
+def get_sdk_client(module, login_data=None):
+    """Get an authenticated Infisical SDK client."""
+    if login_data is not None:
+        try:
+            return create_client_from_login_data(login_data)
+        except (ImportError, ValueError) as e:
+            module.fail_json(msg=str(e))
+
+    try:
+        authenticator = InfisicalAuthenticator(
+            url=module.params['url'],
+            auth_method=module.params['auth_method'],
+            client_id=module.params['universal_auth_client_id'],
+            client_secret=module.params['universal_auth_client_secret'],
+            identity_id=module.params['identity_id'],
+            jwt=module.params['jwt'],
+            token=module.params['token'],
+            ldap_username=module.params['ldap_username'],
+            ldap_password=module.params['ldap_password'],
+        )
+        return authenticator.authenticate()
+    except (ImportError, ValueError) as e:
+        module.fail_json(msg=str(e))
+
+
+def run_module():
+    module_args = dict(
+        login_data=dict(type='dict', no_log=True),
+        url=dict(type='str', default='https://app.infisical.com'),
+        auth_method=dict(
+            type='str',
+            default='universal_auth',
+            choices=['universal_auth', 'oidc_auth', 'token_auth', 'ldap_auth']
+        ),
+        universal_auth_client_id=dict(type='str'),
+        universal_auth_client_secret=dict(type='str', no_log=True),
+        identity_id=dict(type='str'),
+        jwt=dict(type='str', no_log=True),
+        token=dict(type='str', no_log=True),
+        ldap_username=dict(type='str'),
+        ldap_password=dict(type='str', no_log=True),
+        project_id=dict(type='str', required=True),
+        env_slug=dict(type='str', required=True),
+        path=dict(type='str', default='/'),
+        recursive=dict(type='bool', default=False),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    if module.check_mode:
+        module.exit_json(changed=False, folders=[])
+
+    try:
+        login_data = module.params.get('login_data')
+        client = get_sdk_client(module, login_data=login_data)
+
+        response = client.folders.list_folders(
+            project_id=module.params['project_id'],
+            environment_slug=module.params['env_slug'],
+            path=module.params['path'],
+            recursive=module.params['recursive'],
+        )
+
+        module.exit_json(
+            changed=False,
+            folders=[f.to_dict() for f in response.folders],
+        )
+    except Exception as e:
+        module.fail_json(msg=f"Error listing folders: {type(e).__name__}: {e}")
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

Adds support for managing folders in Infisical from Ansible playbooks. Folders are the hierarchical containers used to organize secrets by path; until now the collection could read and write secrets at a path but could not create the path itself, forcing operators to pre-create folders through the UI or the API.

## Changes

- **`plugins/modules/create_folder.py`** — new module. Wraps `client.folders.create_folder(...)`. Accepts `project_id`, `env_slug`, `path` (parent path, default `/`), `name`, and optional `description`. **Idempotent**: lists folders at the parent path first; if a folder with the requested `name` already exists, returns it with `changed=False`. If the existing folder's `description` differs from the requested one, emits a warning (the SDK does not support folder updates). Requires list-folders permission at the parent path.
- **`plugins/modules/list_folders.py`** — new module. Wraps `client.folders.list_folders(...)`. Supports a `recursive` flag for walking the folder tree.
- **`plugins/lookup/list_folders.py`** — new lookup plugin, mirroring the existing `read_secrets` lookup so folder listings can be used inline in Jinja expressions.
- **`README.md`** — documents the new modules and lookup under a new "Folders" section in the plugin index, plus a usage block with create/list/recursive-list examples.

Conventions followed from the rest of the collection:

- All three plugins go through the shared `InfisicalAuthenticator` / `create_client_from_login_data` helpers in `plugins/module_utils/_authenticator.py` — no second auth path.
- All four authentication methods are supported (`universal_auth`, `oidc_auth`, `token_auth`, `ldap_auth`), and `login_data` from `infisical.vault.login` is accepted as an alternative to inline credentials.
- `supports_check_mode=True` with a no-API-call early return.
- Errors from configuration vs. the API are separated the same way as in `create_secret` / `delete_secret`.

## Usage

```yaml
- name: Login to Infisical
  infisical.vault.login:
    url: "https://app.infisical.com"
    auth_method: universal_auth
    universal_auth_client_id: "{{ client_id }}"
    universal_auth_client_secret: "{{ client_secret }}"
  register: infisical_login

# Create a top-level folder (idempotent — safe to re-run)
- name: Create services folder
  infisical.vault.create_folder:
    login_data: "{{ infisical_login.login_data }}"
    project_id: "{{ project_id }}"
    env_slug: "dev"
    path: "/"
    name: "services"

# Create a nested folder with a description
- name: Create backend folder under /services
  infisical.vault.create_folder:
    login_data: "{{ infisical_login.login_data }}"
    project_id: "{{ project_id }}"
    env_slug: "dev"
    path: "/services"
    name: "backend"
    description: "Secrets for the backend service"

# Running the same task again returns changed=False
- name: Ensure backend folder exists
  infisical.vault.create_folder:
    login_data: "{{ infisical_login.login_data }}"
    project_id: "{{ project_id }}"
    env_slug: "dev"
    path: "/services"
    name: "backend"
  register: result
- debug: var=result.changed   # => false

# List folders at a path (module form)
- name: List folders at /
  infisical.vault.list_folders:
    login_data: "{{ infisical_login.login_data }}"
    project_id: "{{ project_id }}"
    env_slug: "dev"
    path: "/"
  register: result

- debug:
    msg: "{{ result.folders | map(attribute='name') | list }}"

# Recursive listing (module form)
- name: List all folders under /services
  infisical.vault.list_folders:
    login_data: "{{ infisical_login.login_data }}"
    project_id: "{{ project_id }}"
    env_slug: "dev"
    path: "/services"
    recursive: true
  register: result

# Lookup form — usable inline in Jinja
- name: Fetch folder list inline
  set_fact:
    folders: "{{ lookup('infisical.vault.list_folders', login_data=infisical_login.login_data, project_id=project_id, env_slug='prod', path='/', recursive=true) }}"
```