### PR TITLE
fix: update token parameter in login module to ensure proper handling…

### DIFF
--- a/plugins/doc_fragments/auth.py
+++ b/plugins/doc_fragments/auth.py
@@ -109,6 +109,23 @@ _TOKEN_AUTH_MODULE = """
     no_log: true
 """
 
+# Login-specific variant. The login module returns this value as C(login_data.access_token),
+# so C(no_log) must be disabled (otherwise Ansible scrubs the identical return value). The
+# description warns operators that the token therefore appears in verbose output and logs.
+_TOKEN_AUTH_LOGIN_MODULE = """
+  token:
+    description:
+      - An access token used to authenticate with Infisical. This can be either a Machine Identity
+        Token Auth token or a User JWT token. Both token types can be used interchangeably with this field.
+      - >-
+        For C(token_auth), this value is returned unchanged as C(access_token) in the login data. So that
+        it stays usable by later tasks, C(no_log) is disabled for this option, which means the token is
+        visible in verbose output (C(-v)/C(-vvv)), in any file set via C(ANSIBLE_LOG_PATH), and in CI/CD
+        logs. Set C(no_log: true) on the task to keep it out of output and logs.
+    type: str
+    no_log: false
+"""
+
 _LDAP_AUTH_MODULE = """
   ldap_username:
     description: The LDAP username used to authenticate (for ldap_auth).
@@ -182,7 +199,7 @@ options:
         auth_method=_AUTH_METHOD_MODULE,
         universal_auth=_UNIVERSAL_AUTH_MODULE,
         oidc_auth=_OIDC_AUTH_MODULE,
-        token_auth=_TOKEN_AUTH_MODULE,
+        token_auth=_TOKEN_AUTH_LOGIN_MODULE,
         ldap_auth=_LDAP_AUTH_MODULE,
     )
 

--- a/plugins/modules/login.py
+++ b/plugins/modules/login.py
@@ -21,6 +21,15 @@ seealso:
 
 notes:
   - The returned login data contains the access token and can be registered for reuse in subsequent tasks.
+  - >
+    For C(token_auth), the value passed in C(token) is returned unchanged as C(access_token) in the login
+    data. So that it stays usable by later tasks, C(no_log) is disabled for the C(token) option, which means
+    the token appears in verbose output (C(-v)/C(-vvv)), in any file set via C(ANSIBLE_LOG_PATH), and in
+    CI/CD logs. This does not apply to the other authentication methods, whose returned token differs from
+    the credentials you supply.
+  - >
+    To keep the token out of output and logs, set C(no_log: true) on this task. The registered login data
+    still contains the usable token for subsequent tasks.
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/login.py
+++ b/plugins/modules/login.py
@@ -101,7 +101,11 @@ def run_module():
         universal_auth_client_secret=dict(type='str', no_log=True),
         identity_id=dict(type='str'),
         jwt=dict(type='str', no_log=True),
-        token=dict(type='str', no_log=True),
+        # token_auth returns this same value as login_data.access_token. With
+        # no_log=True, Ansible's remove_values() scrubs it to
+        # "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER" in the registered result, which
+        # then fails downstream as a malformed bearer token.
+        token=dict(type='str', no_log=False),
         ldap_username=dict(type='str'),
         ldap_password=dict(type='str', no_log=True),
     )


### PR DESCRIPTION
## Summary

- Fixes `token_auth` login failing downstream when `login` is registered and `login_data` is reused.
- With `token` marked `no_log=True`, Ansible scrubs the echoed `login_data.access_token` to `VALUE_SPECIFIED_IN_NO_LOG_PARAMETER`, causing 403 "malformed access token" errors in later tasks.
- Sets `token` to `no_log=False` so the bearer token survives in registered results.

## Test plan

- [ ] Login with `auth_method: token_auth`, register the result, then pass `login_data` to `read_secrets` — confirm secrets are fetched successfully.
- [ ] Verify other auth methods (`universal_auth`, `oidc_auth`, `ldap_auth`) are unaffected.