### PR TITLE
fix: quote DOCUMENTATION string with colon and Markdown link in create_dynamic_secret

### DIFF
--- a/plugins/modules/create_dynamic_secret.py
+++ b/plugins/modules/create_dynamic_secret.py
@@ -42,7 +42,7 @@ options:
     description:
       - The provider-specific configuration inputs.
       - The structure varies depending on the provider type.
-      - Check the Infisical API documentation for the specific provider inputs: [Dynamic Secrets API Documentation](https://infisical.com/docs/api-reference/endpoints/dynamic-secrets/create#body-provider)
+      - "Check the Infisical API documentation for the specific provider inputs: https://infisical.com/docs/api-reference/endpoints/dynamic-secrets/create#body-provider"
     type: dict
     required: true
   default_ttl:


### PR DESCRIPTION
The `inputs` option description contained an unquoted YAML block list item with a Markdown-style link:

    - Check the Infisical API documentation...: [text](url)

In a YAML block sequence, `word: [...]` is parsed as a mapping key followed by a flow sequence, not a plain string. This causes `ansible-doc` to fail with a YAML parse error when processing this module.

Wrap the string in double quotes and replace the Markdown link with a plain URL. ansible-doc does not render Markdown, so the plain URL is equivalent.