### PR TITLE
feat(folders): add CRUD operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ inventory
 test.yml
 __pycache__
 *.tar.gz
+.env
 
 .vscode
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ LDAP Auth allows you to authenticate using LDAP credentials. You'll need to prov
 ### Lookups
 - `infisical.vault.login` - Authenticate and return reusable login data
 - `infisical.vault.read_secrets` - Read secrets from Infisical
+- `infisical.vault.read_folders` - Read secret folders from Infisical
 
 ### Modules
 
@@ -170,6 +171,12 @@ LDAP Auth allows you to authenticate using LDAP credentials. You'll need to prov
 - `infisical.vault.create_secret` - Create a new secret
 - `infisical.vault.update_secret` - Update an existing secret
 - `infisical.vault.delete_secret` - Delete a secret
+
+**Secret Folders:**
+- `infisical.vault.create_folder` - Create a new folder
+- `infisical.vault.read_folders` - List folders at a path, or get one by ID
+- `infisical.vault.update_folder` - Rename or re-describe an existing folder
+- `infisical.vault.delete_folder` - Delete a folder
 
 **Dynamic Secrets:**
 - `infisical.vault.create_dynamic_secret` - Create a dynamic secret
@@ -244,6 +251,72 @@ LDAP Auth allows you to authenticate using LDAP credentials. You'll need to prov
     env_slug: "dev"
     path: "/"
     secret_name: "API_KEY"
+```
+
+### Managing Folders (CRUD)
+
+Folders are the path namespace the secret modules address with `path`. Create one before writing secrets into it.
+
+> `update_folder` and `delete_folder` require a version of the `infisicalsdk` Python package that includes folder update and delete support. The modules fail with a clear message when the installed SDK is too old.
+
+```yaml
+- name: Create a folder
+  infisical.vault.create_folder:
+    login_data: "{{ infisical_login.login_data }}"
+    project_id: "{{ project_id }}"
+    env_slug: "dev"
+    path: "/"
+    name: "services"
+    description: "Per-service secrets"
+  register: created_folder
+
+- name: List the folders at the root
+  infisical.vault.read_folders:
+    login_data: "{{ infisical_login.login_data }}"
+    project_id: "{{ project_id }}"
+    env_slug: "dev"
+    path: "/"
+  register: folders
+
+- name: Show the folder names
+  debug:
+    msg: "{{ folders.folders | map(attribute='name') | list }}"
+
+- name: Get a single folder by ID
+  infisical.vault.read_folders:
+    login_data: "{{ infisical_login.login_data }}"
+    folder_id: "{{ created_folder.folder.id }}"
+  register: one_folder
+
+- name: Rename the folder (update accepts only a folder ID, not a name)
+  infisical.vault.update_folder:
+    login_data: "{{ infisical_login.login_data }}"
+    project_id: "{{ project_id }}"
+    env_slug: "dev"
+    path: "/"
+    folder_id: "{{ created_folder.folder.id }}"
+    name: "apps"
+
+- name: Delete the folder and everything inside it
+  infisical.vault.delete_folder:
+    login_data: "{{ infisical_login.login_data }}"
+    project_id: "{{ project_id }}"
+    env_slug: "dev"
+    path: "/"
+    folder_id_or_name: "apps"
+    force_delete: true
+```
+
+Folders can also be read inline with the lookup plugin:
+
+```yaml
+- name: Read folders with a lookup
+  set_fact:
+    folder_names: "{{ lookup('infisical.vault.read_folders',
+      login_data=infisical_login,
+      project_id=project_id,
+      env_slug='dev',
+      path='/') | map(attribute='name') | list }}"
 ```
 
 ### Dynamic Secrets

--- a/plugins/lookup/read_folders.py
+++ b/plugins/lookup/read_folders.py
@@ -1,0 +1,235 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible.errors import AnsibleError
+from ansible.plugins.lookup import LookupBase
+
+from ansible_collections.infisical.vault.plugins.module_utils._authenticator import (
+    InfisicalAuthenticator,
+    create_client_from_login_data,
+)
+
+
+DOCUMENTATION = r"""
+name: read_folders
+author:
+  - Infisical Inc.
+
+short_description: Look up secret folders stored in Infisical
+description:
+  - Retrieve secret folders from Infisical, granted the caller has the right permissions to access them.
+  - Folders can be located either by environment and parent path to list everything within that scope, or by their ID for a single folder.
+  - You can either provide authentication credentials directly, or use C(login_data) from a previous C(infisical.vault.login) lookup to reuse an authenticated session.
+extends_documentation_fragment:
+  - infisical.vault.auth.lookup
+
+seealso:
+  - ref: infisical.vault.login lookup
+    description: Use the login lookup to authenticate once and reuse the session.
+
+options:
+  path:
+    description:
+      - "The parent folder path to list folders from. For example: /services"
+      - Required unless C(folder_id) is given.
+    required: False
+    type: string
+    version_added: 1.2.0
+  env_slug:
+    description: "Used to select from which environment (environment slug) folders should be fetched from. Environment slug is the short name of a given environment. Required unless C(folder_id) is given."
+    required: False
+    type: string
+    version_added: 1.2.0
+  project_id:
+    description: "The ID of the project where the folders are stored. Required unless C(folder_id) is given."
+    required: False
+    type: string
+    version_added: 1.2.0
+  folder_id:
+    description: The ID of a single folder that should be fetched. When given, C(project_id), C(env_slug), and C(path) are not used.
+    required: False
+    type: string
+    version_added: 1.2.0
+  recursive:
+    description: List folders recursively below C(path) instead of only its direct children. Only applies when listing by C(path).
+    required: False
+    type: bool
+    default: False
+    version_added: 1.2.0
+"""
+
+EXAMPLES = r"""
+# Direct authentication (authenticates on each call)
+vars:
+  root_folders: "{{ lookup('infisical.vault.read_folders', universal_auth_client_id='<client-id>', universal_auth_client_secret='<client-secret>', project_id='<project-id>', path='/', env_slug='dev', url='https://app.infisical.com') }}"
+  # [{ "id": "...", "name": "services", "relativePath": "/services", ... }]
+
+# Using login_data from infisical.vault.login (recommended for multiple lookups)
+# This avoids re-authenticating on each call
+- name: Login to Infisical once
+  set_fact:
+    infisical_login: "{{ lookup('infisical.vault.login', url='https://app.infisical.com', auth_method='universal_auth', universal_auth_client_id='<client-id>', universal_auth_client_secret='<client-secret>') }}"
+
+- name: List the folders under /services
+  set_fact:
+    service_folders: "{{ lookup('infisical.vault.read_folders', login_data=infisical_login, project_id='<project-id>', path='/services', env_slug='prod') }}"
+
+- name: List every folder below the project root
+  set_fact:
+    all_folders: "{{ lookup('infisical.vault.read_folders', login_data=infisical_login, project_id='<project-id>', path='/', env_slug='prod', recursive=True) }}"
+
+- name: Collect just the folder names
+  set_fact:
+    folder_names: "{{ lookup('infisical.vault.read_folders', login_data=infisical_login, project_id='<project-id>', path='/', env_slug='prod') | map(attribute='name') | list }}"
+
+- name: Fetch a single folder by ID
+  set_fact:
+    one_folder: "{{ lookup('infisical.vault.read_folders', login_data=infisical_login, folder_id='a1b2c3d4-e5f6-7890-abcd-ef1234567890') }}"
+"""
+
+RETURN = r"""
+_list:
+  description:
+    - A list of folder objects.
+    - When C(folder_id) is given, the list contains exactly one folder.
+  type: list
+  elements: dict
+  contains:
+    id:
+      description: The unique identifier of the folder.
+      type: str
+    name:
+      description: The name of the folder.
+      type: str
+    relativePath:
+      description: The path of the folder relative to the requested path (when listing by C(path)).
+      type: str
+    path:
+      description: The full path of the folder (when fetching by C(folder_id)).
+      type: str
+    projectId:
+      description: The ID of the project the folder belongs to (when fetching by C(folder_id)).
+      type: str
+    environment:
+      description: The environment the folder belongs to (when fetching by C(folder_id)).
+      type: dict
+    description:
+      description: The description of the folder.
+      type: str
+    envId:
+      description: The ID of the environment the folder belongs to.
+      type: str
+    parentId:
+      description: The ID of the parent folder.
+      type: str
+    version:
+      description: The version number of the folder.
+      type: int
+    isReserved:
+      description: Whether the folder is reserved by Infisical.
+      type: bool
+    lastSecretModified:
+      description: Timestamp of the last secret modification within the folder.
+      type: str
+    createdAt:
+      description: The creation timestamp.
+      type: str
+    updatedAt:
+      description: The last update timestamp.
+      type: str
+"""
+
+
+class LookupModule(LookupBase):
+
+    def _get_sdk_client(self, login_data=None):
+        """Get an authenticated Infisical SDK client.
+
+        Args:
+            login_data: Optional login data dict from infisical.vault.login lookup.
+                       Contains url and access_token for authentication.
+
+        Returns:
+            An authenticated InfisicalSDKClient instance
+        """
+        # If login_data is provided, create a client using the saved token
+        if login_data is not None:
+            try:
+                return create_client_from_login_data(login_data)
+            except (ImportError, ValueError) as e:
+                raise AnsibleError(f"Configuration error creating client from login_data: {e}")
+            except Exception as e:
+                raise AnsibleError(f"Failed to create client from login_data: {type(e).__name__}: {e}")
+
+        # Otherwise, authenticate fresh
+        authenticator = InfisicalAuthenticator(
+            url=self.get_option('url'),
+            auth_method=self.get_option('auth_method'),
+            client_id=self.get_option('universal_auth_client_id'),
+            client_secret=self.get_option('universal_auth_client_secret'),
+            identity_id=self.get_option('identity_id'),
+            jwt=self.get_option('jwt'),
+            token=self.get_option('token'),
+            ldap_username=self.get_option('ldap_username'),
+            ldap_password=self.get_option('ldap_password'),
+        )
+
+        try:
+            return authenticator.authenticate()
+        except (ImportError, ValueError) as e:
+            raise AnsibleError(f"Configuration error during Infisical authentication: {e}")
+        except Exception as e:
+            raise AnsibleError(f"Failed to authenticate with Infisical: {type(e).__name__}: {e}")
+
+    def run(self, terms, variables=None, **kwargs):
+        self.set_options(var_options=variables, direct=kwargs)
+
+        # Get login_data if provided
+        login_data = kwargs.get('login_data')
+
+        folder_id = kwargs.get('folder_id')
+        env_slug = kwargs.get('env_slug')
+        path = kwargs.get('path')
+        project_id = kwargs.get('project_id')
+        recursive = kwargs.get('recursive', False)
+
+        if not folder_id:
+            missing = [
+                name for name, value in (
+                    ('project_id', project_id),
+                    ('env_slug', env_slug),
+                    ('path', path),
+                ) if not value
+            ]
+            if missing:
+                raise AnsibleError(
+                    "Configuration error: read_folders requires either 'folder_id' or "
+                    f"'project_id', 'env_slug' and 'path'. Missing: {', '.join(missing)}"
+                )
+
+        client = self._get_sdk_client(login_data=login_data)
+
+        if folder_id:
+            return self._get_single_folder(client, folder_id)
+        return self._get_all_folders(client, project_id, env_slug, path, recursive)
+
+    def _get_single_folder(self, client, folder_id):
+        """Fetch a single folder by ID."""
+        try:
+            folder = client.folders.get_folder_by_id(id=folder_id)
+            return [folder.to_dict()]
+        except Exception as e:
+            raise AnsibleError(f"Error fetching folder '{folder_id}': {e}")
+
+    def _get_all_folders(self, client, project_id, environment, path, recursive=False):
+        """Fetch all folders within the specified scope."""
+        try:
+            response = client.folders.list_folders(
+                project_id=project_id,
+                environment_slug=environment,
+                path=path,
+                recursive=recursive,
+            )
+            return [folder.to_dict() for folder in response.folders]
+        except Exception as e:
+            raise AnsibleError(f"Error fetching folders: {e}")

--- a/plugins/modules/create_folder.py
+++ b/plugins/modules/create_folder.py
@@ -1,0 +1,227 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: create_folder
+short_description: Create a secret folder in Infisical
+version_added: "1.2.0"
+author:
+  - Infisical Inc.
+description:
+  - Create a new secret folder in Infisical.
+  - The folder will be created under the specified parent path and environment.
+extends_documentation_fragment:
+  - infisical.vault.auth
+
+options:
+  project_id:
+    description: The ID of the project where the folder will be created.
+    type: str
+    required: true
+  env_slug:
+    description: >
+      The environment slug where the folder will be created.
+      Environment slug is the short name of a given environment.
+    type: str
+    required: true
+  path:
+    description: "The parent folder path the new folder will be created under. For example: /services"
+    type: str
+    required: true
+  name:
+    description: The name of the folder to create.
+    type: str
+    required: true
+  description:
+    description: An optional description for the folder.
+    type: str
+
+seealso:
+  - module: infisical.vault.login
+    description: Use the login module to authenticate once and reuse the session.
+  - module: infisical.vault.read_folders
+    description: Read secret folders from Infisical.
+  - module: infisical.vault.update_folder
+    description: Update an existing secret folder.
+  - module: infisical.vault.delete_folder
+    description: Delete a secret folder.
+"""
+
+EXAMPLES = r"""
+# Create a folder with direct authentication
+- name: Create a new folder
+  infisical.vault.create_folder:
+    url: "https://app.infisical.com"
+    auth_method: universal_auth
+    universal_auth_client_id: "{{ client_id }}"
+    universal_auth_client_secret: "{{ client_secret }}"
+    project_id: "my-project-id"
+    env_slug: "dev"
+    path: "/"
+    name: "services"
+  register: created_folder
+
+# Create a folder using login_data
+- name: Login to Infisical
+  infisical.vault.login:
+    url: "https://app.infisical.com"
+    auth_method: universal_auth
+    universal_auth_client_id: "{{ client_id }}"
+    universal_auth_client_secret: "{{ client_secret }}"
+  register: infisical_login
+
+- name: Create a nested folder with a description
+  infisical.vault.create_folder:
+    login_data: "{{ infisical_login.login_data }}"
+    project_id: "my-project-id"
+    env_slug: "prod"
+    path: "/services"
+    name: "backend"
+    description: "Secrets for the backend service"
+  register: created_folder
+
+- name: Create a secret inside the new folder
+  infisical.vault.create_secret:
+    login_data: "{{ infisical_login.login_data }}"
+    project_id: "my-project-id"
+    env_slug: "prod"
+    path: "/services/backend"
+    secret_name: "DB_PASSWORD"
+    secret_value: "super-secret-password"
+"""
+
+RETURN = r"""
+folder:
+  description: The created folder.
+  returned: success
+  type: dict
+  contains:
+    id:
+      description: The unique identifier of the folder.
+      type: str
+    name:
+      description: The name of the folder.
+      type: str
+    path:
+      description: The full path of the folder.
+      type: str
+    description:
+      description: The description of the folder.
+      type: str
+    envId:
+      description: The ID of the environment the folder belongs to.
+      type: str
+    parentId:
+      description: The ID of the parent folder.
+      type: str
+    version:
+      description: The version number of the folder.
+      type: int
+    isReserved:
+      description: Whether the folder is reserved by Infisical.
+      type: bool
+    lastSecretModified:
+      description: Timestamp of the last secret modification within the folder.
+      type: str
+    createdAt:
+      description: The creation timestamp.
+      type: str
+    updatedAt:
+      description: The last update timestamp.
+      type: str
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.infisical.vault.plugins.module_utils._authenticator import (
+    InfisicalAuthenticator,
+    create_client_from_login_data,
+)
+
+
+def get_sdk_client(module, login_data=None):
+    """Get an authenticated Infisical SDK client."""
+    if login_data is not None:
+        try:
+            return create_client_from_login_data(login_data)
+        except (ImportError, ValueError) as e:
+            module.fail_json(msg=str(e))
+
+    try:
+        authenticator = InfisicalAuthenticator(
+            url=module.params['url'],
+            auth_method=module.params['auth_method'],
+            client_id=module.params['universal_auth_client_id'],
+            client_secret=module.params['universal_auth_client_secret'],
+            identity_id=module.params['identity_id'],
+            jwt=module.params['jwt'],
+            token=module.params['token'],
+        )
+        return authenticator.authenticate()
+    except (ImportError, ValueError) as e:
+        module.fail_json(msg=str(e))
+
+
+def run_module():
+    module_args = dict(
+        login_data=dict(type='dict', no_log=True),
+        url=dict(type='str', default='https://app.infisical.com'),
+        auth_method=dict(
+            type='str',
+            default='universal_auth',
+            choices=['universal_auth', 'oidc_auth', 'token_auth']
+        ),
+        universal_auth_client_id=dict(type='str'),
+        universal_auth_client_secret=dict(type='str', no_log=True),
+        identity_id=dict(type='str'),
+        jwt=dict(type='str', no_log=True),
+        token=dict(type='str', no_log=True),
+        project_id=dict(type='str', required=True),
+        env_slug=dict(type='str', required=True),
+        path=dict(type='str', required=True),
+        name=dict(type='str', required=True),
+        description=dict(type='str'),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    if module.check_mode:
+        module.exit_json(
+            changed=True,
+            folder={'name': module.params['name'], 'path': module.params['path']},
+        )
+
+    try:
+        login_data = module.params.get('login_data')
+        client = get_sdk_client(module, login_data=login_data)
+
+        create_kwargs = dict(
+            name=module.params['name'],
+            project_id=module.params['project_id'],
+            environment_slug=module.params['env_slug'],
+            path=module.params['path'],
+        )
+
+        if module.params.get('description') is not None:
+            create_kwargs['description'] = module.params['description']
+
+        folder = client.folders.create_folder(**create_kwargs)
+
+        module.exit_json(
+            changed=True,
+            folder=folder.to_dict(),
+        )
+    except Exception as e:
+        module.fail_json(msg=f"Error creating folder: {type(e).__name__}: {e}")
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/delete_folder.py
+++ b/plugins/modules/delete_folder.py
@@ -1,0 +1,228 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: delete_folder
+short_description: Delete a secret folder in Infisical
+version_added: "1.2.0"
+author:
+  - Infisical Inc.
+description:
+  - Delete a secret folder from Infisical.
+  - The folder must already exist and can be identified by either its ID or its name.
+extends_documentation_fragment:
+  - infisical.vault.auth
+
+options:
+  project_id:
+    description: The ID of the project where the folder resides.
+    type: str
+    required: true
+  env_slug:
+    description: >
+      The environment slug where the folder resides.
+      Environment slug is the short name of a given environment.
+    type: str
+    required: true
+  path:
+    description: "The parent folder path the folder resides in. For example: /services"
+    type: str
+    required: true
+  folder_id_or_name:
+    description: The ID or the name of the folder to delete.
+    type: str
+    required: true
+  force_delete:
+    description:
+      - Delete the folder even when it still contains secrets or subfolders.
+      - Everything inside the folder is removed along with it.
+    type: bool
+    default: false
+
+notes:
+  - Requires a version of the C(infisicalsdk) Python package that supports folder deletion.
+
+seealso:
+  - module: infisical.vault.login
+    description: Use the login module to authenticate once and reuse the session.
+  - module: infisical.vault.create_folder
+    description: Create a secret folder.
+  - module: infisical.vault.read_folders
+    description: Read secret folders from Infisical.
+  - module: infisical.vault.update_folder
+    description: Update an existing secret folder.
+"""
+
+EXAMPLES = r"""
+# Delete a folder by name with direct authentication
+- name: Delete a folder
+  infisical.vault.delete_folder:
+    url: "https://app.infisical.com"
+    auth_method: universal_auth
+    universal_auth_client_id: "{{ client_id }}"
+    universal_auth_client_secret: "{{ client_secret }}"
+    project_id: "my-project-id"
+    env_slug: "dev"
+    path: "/services"
+    folder_id_or_name: "backend"
+  register: deleted_folder
+
+# Delete a folder using login_data
+- name: Login to Infisical
+  infisical.vault.login:
+    url: "https://app.infisical.com"
+    auth_method: universal_auth
+    universal_auth_client_id: "{{ client_id }}"
+    universal_auth_client_secret: "{{ client_secret }}"
+  register: infisical_login
+
+- name: Delete a folder along with everything inside it
+  infisical.vault.delete_folder:
+    login_data: "{{ infisical_login.login_data }}"
+    project_id: "my-project-id"
+    env_slug: "prod"
+    path: "/services"
+    folder_id_or_name: "backend"
+    force_delete: true
+  register: deleted_folder
+
+- name: Delete a folder by ID
+  infisical.vault.delete_folder:
+    login_data: "{{ infisical_login.login_data }}"
+    project_id: "my-project-id"
+    env_slug: "prod"
+    path: "/services"
+    folder_id_or_name: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+  register: deleted_folder
+"""
+
+RETURN = r"""
+folder:
+  description:
+    - The deleted folder.
+    - The delete response does not include the folder path.
+  returned: success
+  type: dict
+  contains:
+    id:
+      description: The unique identifier of the folder.
+      type: str
+    name:
+      description: The name of the folder.
+      type: str
+    description:
+      description: The description of the folder.
+      type: str
+    envId:
+      description: The ID of the environment the folder belonged to.
+      type: str
+    parentId:
+      description: The ID of the parent folder.
+      type: str
+    version:
+      description: The version number of the folder.
+      type: int
+    isReserved:
+      description: Whether the folder is reserved by Infisical.
+      type: bool
+    lastSecretModified:
+      description: Timestamp of the last secret modification within the folder.
+      type: str
+    createdAt:
+      description: The creation timestamp.
+      type: str
+    updatedAt:
+      description: The last update timestamp.
+      type: str
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.infisical.vault.plugins.module_utils._authenticator import (
+    InfisicalAuthenticator,
+    create_client_from_login_data,
+)
+
+
+def get_sdk_client(module, login_data=None):
+    """Get an authenticated Infisical SDK client."""
+    if login_data is not None:
+        try:
+            return create_client_from_login_data(login_data)
+        except (ImportError, ValueError) as e:
+            module.fail_json(msg=str(e))
+
+    try:
+        authenticator = InfisicalAuthenticator(
+            url=module.params['url'],
+            auth_method=module.params['auth_method'],
+            client_id=module.params['universal_auth_client_id'],
+            client_secret=module.params['universal_auth_client_secret'],
+            identity_id=module.params['identity_id'],
+            jwt=module.params['jwt'],
+            token=module.params['token'],
+        )
+        return authenticator.authenticate()
+    except (ImportError, ValueError) as e:
+        module.fail_json(msg=str(e))
+
+
+def run_module():
+    module_args = dict(
+        login_data=dict(type='dict', no_log=True),
+        url=dict(type='str', default='https://app.infisical.com'),
+        auth_method=dict(
+            type='str',
+            default='universal_auth',
+            choices=['universal_auth', 'oidc_auth', 'token_auth']
+        ),
+        universal_auth_client_id=dict(type='str'),
+        universal_auth_client_secret=dict(type='str', no_log=True),
+        identity_id=dict(type='str'),
+        jwt=dict(type='str', no_log=True),
+        token=dict(type='str', no_log=True),
+        project_id=dict(type='str', required=True),
+        env_slug=dict(type='str', required=True),
+        path=dict(type='str', required=True),
+        folder_id_or_name=dict(type='str', required=True),
+        force_delete=dict(type='bool', default=False),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    if module.check_mode:
+        module.exit_json(
+            changed=True,
+            folder={'name': module.params['folder_id_or_name'], 'path': module.params['path']},
+        )
+
+    try:
+        login_data = module.params.get('login_data')
+        client = get_sdk_client(module, login_data=login_data)
+
+        folder = client.folders.delete_folder(
+            folder_id_or_name=module.params['folder_id_or_name'],
+            project_id=module.params['project_id'],
+            environment_slug=module.params['env_slug'],
+            path=module.params['path'],
+            force_delete=module.params['force_delete'],
+        )
+
+        module.exit_json(
+            changed=True,
+            folder=folder.to_dict(),
+        )
+    except Exception as e:
+        module.fail_json(msg=f"Error deleting folder: {type(e).__name__}: {e}")
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/read_folders.py
+++ b/plugins/modules/read_folders.py
@@ -1,0 +1,263 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: read_folders
+short_description: Read secret folders from Infisical
+version_added: "1.2.0"
+author:
+  - Infisical Inc.
+description:
+  - Read secret folders from Infisical.
+  - Folders can be listed by environment and parent path, or fetched individually by their ID.
+extends_documentation_fragment:
+  - infisical.vault.auth
+
+options:
+  project_id:
+    description:
+      - The ID of the project where the folders are stored.
+      - Required when C(path) is used. Ignored when C(folder_id) is used.
+    type: str
+  env_slug:
+    description:
+      - The environment slug to list folders from. Environment slug is the short name of a given environment.
+      - Required when C(path) is used. Ignored when C(folder_id) is used.
+    type: str
+  path:
+    description:
+      - "The parent folder path to list folders from. For example: /services"
+      - Mutually exclusive with C(folder_id). One of C(path) or C(folder_id) is required.
+    type: str
+  folder_id:
+    description:
+      - The ID of a single folder to fetch.
+      - Mutually exclusive with C(path). One of C(path) or C(folder_id) is required.
+    type: str
+  recursive:
+    description:
+      - List folders recursively below C(path) instead of only its direct children.
+      - Only applies when listing by C(path).
+    type: bool
+    default: false
+
+notes:
+  - This module is read-only, so it performs the real lookup in check mode rather than returning stub data.
+  - Folders listed by C(path) carry a C(relativePath) field, while a folder fetched by C(folder_id) carries C(path), C(projectId), and a nested C(environment) object.
+
+seealso:
+  - module: infisical.vault.login
+    description: Use the login module to authenticate once and reuse the session.
+  - module: infisical.vault.create_folder
+    description: Create a secret folder.
+  - module: infisical.vault.update_folder
+    description: Update an existing secret folder.
+  - module: infisical.vault.delete_folder
+    description: Delete a secret folder.
+"""
+
+EXAMPLES = r"""
+# List folders with direct authentication
+- name: List folders at the project root
+  infisical.vault.read_folders:
+    url: "https://app.infisical.com"
+    auth_method: universal_auth
+    universal_auth_client_id: "{{ client_id }}"
+    universal_auth_client_secret: "{{ client_secret }}"
+    project_id: "my-project-id"
+    env_slug: "dev"
+    path: "/"
+  register: root_folders
+
+# List folders using login_data
+- name: Login to Infisical
+  infisical.vault.login:
+    url: "https://app.infisical.com"
+    auth_method: universal_auth
+    universal_auth_client_id: "{{ client_id }}"
+    universal_auth_client_secret: "{{ client_secret }}"
+  register: infisical_login
+
+- name: List every folder below /services
+  infisical.vault.read_folders:
+    login_data: "{{ infisical_login.login_data }}"
+    project_id: "my-project-id"
+    env_slug: "prod"
+    path: "/services"
+    recursive: true
+  register: service_folders
+
+- name: Show the folder names
+  ansible.builtin.debug:
+    msg: "{{ service_folders.folders | map(attribute='name') | list }}"
+
+- name: Fetch a single folder by ID
+  infisical.vault.read_folders:
+    login_data: "{{ infisical_login.login_data }}"
+    folder_id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+  register: one_folder
+
+- name: Show the folder
+  ansible.builtin.debug:
+    var: one_folder.folders[0]
+"""
+
+RETURN = r"""
+folders:
+  description:
+    - The folders that were read.
+    - Always a list. When C(folder_id) is used, it contains exactly one folder.
+  returned: success
+  type: list
+  elements: dict
+  contains:
+    id:
+      description: The unique identifier of the folder.
+      type: str
+    name:
+      description: The name of the folder.
+      type: str
+    relativePath:
+      description: The path of the folder relative to the requested path (when listing by C(path)).
+      type: str
+    path:
+      description: The full path of the folder (when fetching by C(folder_id)).
+      type: str
+    projectId:
+      description: The ID of the project the folder belongs to (when fetching by C(folder_id)).
+      type: str
+    environment:
+      description: The environment the folder belongs to (when fetching by C(folder_id)).
+      type: dict
+      contains:
+        envId:
+          description: The ID of the environment.
+          type: str
+        envName:
+          description: The name of the environment.
+          type: str
+        envSlug:
+          description: The slug of the environment.
+          type: str
+    description:
+      description: The description of the folder.
+      type: str
+    envId:
+      description: The ID of the environment the folder belongs to.
+      type: str
+    parentId:
+      description: The ID of the parent folder.
+      type: str
+    version:
+      description: The version number of the folder.
+      type: int
+    isReserved:
+      description: Whether the folder is reserved by Infisical.
+      type: bool
+    lastSecretModified:
+      description: Timestamp of the last secret modification within the folder.
+      type: str
+    createdAt:
+      description: The creation timestamp.
+      type: str
+    updatedAt:
+      description: The last update timestamp.
+      type: str
+"""
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.infisical.vault.plugins.module_utils._authenticator import (
+    InfisicalAuthenticator,
+    create_client_from_login_data,
+)
+
+
+def get_sdk_client(module, login_data=None):
+    """Get an authenticated Infisical SDK client."""
+    if login_data is not None:
+        try:
+            return create_client_from_login_data(login_data)
+        except (ImportError, ValueError) as e:
+            module.fail_json(msg=str(e))
+
+    try:
+        authenticator = InfisicalAuthenticator(
+            url=module.params['url'],
+            auth_method=module.params['auth_method'],
+            client_id=module.params['universal_auth_client_id'],
+            client_secret=module.params['universal_auth_client_secret'],
+            identity_id=module.params['identity_id'],
+            jwt=module.params['jwt'],
+            token=module.params['token'],
+        )
+        return authenticator.authenticate()
+    except (ImportError, ValueError) as e:
+        module.fail_json(msg=str(e))
+
+
+def run_module():
+    module_args = dict(
+        login_data=dict(type='dict', no_log=True),
+        url=dict(type='str', default='https://app.infisical.com'),
+        auth_method=dict(
+            type='str',
+            default='universal_auth',
+            choices=['universal_auth', 'oidc_auth', 'token_auth']
+        ),
+        universal_auth_client_id=dict(type='str'),
+        universal_auth_client_secret=dict(type='str', no_log=True),
+        identity_id=dict(type='str'),
+        jwt=dict(type='str', no_log=True),
+        token=dict(type='str', no_log=True),
+        project_id=dict(type='str'),
+        env_slug=dict(type='str'),
+        path=dict(type='str'),
+        folder_id=dict(type='str'),
+        recursive=dict(type='bool', default=False),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+        mutually_exclusive=[['folder_id', 'path']],
+        required_one_of=[['folder_id', 'path']],
+        required_by={'path': ['project_id', 'env_slug']},
+    )
+
+    try:
+        login_data = module.params.get('login_data')
+        client = get_sdk_client(module, login_data=login_data)
+
+        if module.params.get('folder_id') is not None:
+            folder = client.folders.get_folder_by_id(id=module.params['folder_id'])
+            folders = [folder.to_dict()]
+        else:
+            response = client.folders.list_folders(
+                project_id=module.params['project_id'],
+                environment_slug=module.params['env_slug'],
+                path=module.params['path'],
+                recursive=module.params['recursive'],
+            )
+            folders = [folder.to_dict() for folder in response.folders]
+
+        module.exit_json(
+            changed=False,
+            folders=folders,
+        )
+    except Exception as e:
+        module.fail_json(
+            msg=f"Error reading folders: {type(e).__name__}: {e}",
+            exception=traceback.format_exc(),
+        )
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/update_folder.py
+++ b/plugins/modules/update_folder.py
@@ -1,0 +1,256 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: update_folder
+short_description: Update a secret folder in Infisical
+version_added: "1.2.0"
+author:
+  - Infisical Inc.
+description:
+  - Update an existing secret folder in Infisical.
+  - The folder must already exist and is identified by its ID.
+  - The folder is renamed to C(name), and its description is replaced when C(description) is given.
+extends_documentation_fragment:
+  - infisical.vault.auth
+
+options:
+  project_id:
+    description: The ID of the project where the folder resides.
+    type: str
+    required: true
+  env_slug:
+    description: >
+      The environment slug where the folder resides.
+      Environment slug is the short name of a given environment.
+    type: str
+    required: true
+  path:
+    description: "The parent folder path the folder resides in. For example: /services"
+    type: str
+    required: true
+  folder_id:
+    description:
+      - The ID of the folder to update.
+      - The Infisical update endpoint accepts only an ID, so a folder cannot be targeted by name.
+        Use M(infisical.vault.read_folders) to look up the ID first.
+    type: str
+    required: true
+  name:
+    description:
+      - The new name of the folder.
+      - Required by the Infisical API, so pass the folder's current name to keep it unchanged.
+    type: str
+    required: true
+  description:
+    description:
+      - A new description for the folder.
+      - Omitting this leaves the existing description unchanged. It cannot be used to clear a description.
+    type: str
+
+notes:
+  - Requires a version of the C(infisicalsdk) Python package that supports folder updates.
+
+seealso:
+  - module: infisical.vault.login
+    description: Use the login module to authenticate once and reuse the session.
+  - module: infisical.vault.create_folder
+    description: Create a secret folder.
+  - module: infisical.vault.read_folders
+    description: Read secret folders from Infisical.
+  - module: infisical.vault.delete_folder
+    description: Delete a secret folder.
+"""
+
+EXAMPLES = r"""
+# Rename a folder with direct authentication
+- name: Rename a folder
+  infisical.vault.update_folder:
+    url: "https://app.infisical.com"
+    auth_method: universal_auth
+    universal_auth_client_id: "{{ client_id }}"
+    universal_auth_client_secret: "{{ client_secret }}"
+    project_id: "my-project-id"
+    env_slug: "dev"
+    path: "/services"
+    folder_id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+    name: "backend-api"
+  register: updated_folder
+
+# Update a folder using login_data
+- name: Login to Infisical
+  infisical.vault.login:
+    url: "https://app.infisical.com"
+    auth_method: universal_auth
+    universal_auth_client_id: "{{ client_id }}"
+    universal_auth_client_secret: "{{ client_secret }}"
+  register: infisical_login
+
+- name: Update only the description, keeping the name
+  infisical.vault.update_folder:
+    login_data: "{{ infisical_login.login_data }}"
+    project_id: "my-project-id"
+    env_slug: "prod"
+    path: "/services"
+    folder_id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+    name: "backend"
+    description: "Secrets for the backend service"
+  register: updated_folder
+
+# Look the folder ID up by name first, since update accepts only an ID
+- name: Find the folder
+  infisical.vault.read_folders:
+    login_data: "{{ infisical_login.login_data }}"
+    project_id: "my-project-id"
+    env_slug: "prod"
+    path: "/services"
+  register: service_folders
+
+- name: Rename the folder that was found
+  infisical.vault.update_folder:
+    login_data: "{{ infisical_login.login_data }}"
+    project_id: "my-project-id"
+    env_slug: "prod"
+    path: "/services"
+    folder_id: "{{ (service_folders.folders | selectattr('name', 'eq', 'backend') | first).id }}"
+    name: "backend-api"
+  register: updated_folder
+"""
+
+RETURN = r"""
+folder:
+  description: The updated folder.
+  returned: success
+  type: dict
+  contains:
+    id:
+      description: The unique identifier of the folder.
+      type: str
+    name:
+      description: The name of the folder.
+      type: str
+    path:
+      description: The full path of the folder.
+      type: str
+    description:
+      description: The description of the folder.
+      type: str
+    envId:
+      description: The ID of the environment the folder belongs to.
+      type: str
+    parentId:
+      description: The ID of the parent folder.
+      type: str
+    version:
+      description: The version number of the folder.
+      type: int
+    isReserved:
+      description: Whether the folder is reserved by Infisical.
+      type: bool
+    lastSecretModified:
+      description: Timestamp of the last secret modification within the folder.
+      type: str
+    createdAt:
+      description: The creation timestamp.
+      type: str
+    updatedAt:
+      description: The last update timestamp.
+      type: str
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.infisical.vault.plugins.module_utils._authenticator import (
+    InfisicalAuthenticator,
+    create_client_from_login_data,
+)
+
+
+def get_sdk_client(module, login_data=None):
+    """Get an authenticated Infisical SDK client."""
+    if login_data is not None:
+        try:
+            return create_client_from_login_data(login_data)
+        except (ImportError, ValueError) as e:
+            module.fail_json(msg=str(e))
+
+    try:
+        authenticator = InfisicalAuthenticator(
+            url=module.params['url'],
+            auth_method=module.params['auth_method'],
+            client_id=module.params['universal_auth_client_id'],
+            client_secret=module.params['universal_auth_client_secret'],
+            identity_id=module.params['identity_id'],
+            jwt=module.params['jwt'],
+            token=module.params['token'],
+        )
+        return authenticator.authenticate()
+    except (ImportError, ValueError) as e:
+        module.fail_json(msg=str(e))
+
+
+def run_module():
+    module_args = dict(
+        login_data=dict(type='dict', no_log=True),
+        url=dict(type='str', default='https://app.infisical.com'),
+        auth_method=dict(
+            type='str',
+            default='universal_auth',
+            choices=['universal_auth', 'oidc_auth', 'token_auth']
+        ),
+        universal_auth_client_id=dict(type='str'),
+        universal_auth_client_secret=dict(type='str', no_log=True),
+        identity_id=dict(type='str'),
+        jwt=dict(type='str', no_log=True),
+        token=dict(type='str', no_log=True),
+        project_id=dict(type='str', required=True),
+        env_slug=dict(type='str', required=True),
+        path=dict(type='str', required=True),
+        folder_id=dict(type='str', required=True),
+        name=dict(type='str', required=True),
+        description=dict(type='str'),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    if module.check_mode:
+        module.exit_json(
+            changed=True,
+            folder={'name': module.params['name'], 'path': module.params['path']},
+        )
+
+    try:
+        login_data = module.params.get('login_data')
+        client = get_sdk_client(module, login_data=login_data)
+
+        update_kwargs = dict(
+            folder_id=module.params['folder_id'],
+            name=module.params['name'],
+            project_id=module.params['project_id'],
+            environment_slug=module.params['env_slug'],
+            path=module.params['path'],
+        )
+
+        if module.params.get('description') is not None:
+            update_kwargs['description'] = module.params['description']
+
+        folder = client.folders.update_folder(**update_kwargs)
+
+        module.exit_json(
+            changed=True,
+            folder=folder.to_dict(),
+        )
+    except Exception as e:
+        module.fail_json(msg=f"Error updating folder: {type(e).__name__}: {e}")
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
### How to test 
- to validate this you need to create the python SDK using this [version](https://github.com/Infisical/python-sdk-official/pull/58) that supports folders 
- Create a `.yml` for validation (example at the end)
- Create the SDK locally (`python3 -m pip install -e ~/YOUR_PATH/python-sdk-official`)
- Here is the command to run 
```
set -a; . ./.env; set +a
  ansible-playbook test_folders.yml > /tmp/folders-run.log 2>&1; echo
  "EXIT: $?"
  tail -30 /tmp/folders-run.log
```


```
---
# Test playbook for the Infisical secret folder modules and the read_folders lookup.
#
# Exercises the full lifecycle: create -> list -> get by id -> list recursive ->
# lookup -> update (id from the listing) -> update (id from create) -> delete ->
# confirm gone.
#
# Note: update_folder accepts only a folder ID, matching the Infisical API, so the
# rename steps resolve the ID first. delete_folder does accept a name.
#
# Prerequisites:
#   1. Activate the venv:  source .venv/bin/activate
#   2. Make sure the installed infisicalsdk has folder update/delete support
#      (i.e. python-sdk-official PR #58). Verify with:
#        python -c "from infisical_sdk.resources.folders import V2Folders as F; \
#                   print(sorted(m for m in dir(F) if 'folder' in m))"
#   3. Install the collection:  ansible-galaxy collection install . --force
#   4. Export credentials:
#        export INFISICAL_UNIVERSAL_AUTH_CLIENT_ID=...
#        export INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET=...
#        export INFISICAL_PROJECT_ID=...
#      Optional:
#        export INFISICAL_URL=https://app.infisical.com
#        export INFISICAL_ENV_SLUG=dev
#        export INFISICAL_FOLDER_PARENT_PATH=/
#        export INFISICAL_FOLDER_NAME=ansible-test-folder
#
# Run:
#   ansible-playbook test_folders.yml
#
# On macOS, the forked Ansible worker can crash with
# "+[NSNumber initialize] may have been in progress in another thread when fork()
# was called" / "A worker was found in a dead state". If that happens:
#   export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
#
# Check mode (mutating tasks return stub data, reads return real data):
#   ansible-playbook test_folders.yml --check
#
# Note: this playbook creates and then deletes a folder in the target project.
# If it fails midway, delete the leftover folder manually (name is
# INFISICAL_FOLDER_NAME, possibly with a "-renamed" suffix).

- name: Test Infisical folder CRUD
  hosts: localhost
  connection: local
  gather_facts: false

  vars:
    infisical_url: "{{ lookup('env', 'INFISICAL_URL') | default('https://app.infisical.com', true) }}"
    project_id: "{{ lookup('env', 'INFISICAL_PROJECT_ID') }}"
    env_slug: "{{ lookup('env', 'INFISICAL_ENV_SLUG') | default('dev', true) }}"
    parent_path: "{{ lookup('env', 'INFISICAL_FOLDER_PARENT_PATH') | default('/', true) }}"
    folder_name: "{{ lookup('env', 'INFISICAL_FOLDER_NAME') | default('ansible-test-folder', true) }}"
    renamed_folder_name: "{{ folder_name }}-renamed"

  tasks:
    - name: Require project ID
      ansible.builtin.assert:
        that:
          - project_id | length > 0
        fail_msg: >-
          Set INFISICAL_PROJECT_ID (and Universal Auth client id/secret env vars) before running.

    - name: Login to Infisical once
      ansible.builtin.set_fact:
        infisical_login: "{{ lookup('infisical.vault.login',
          url=infisical_url,
          auth_method='universal_auth',
          universal_auth_client_id=lookup('env', 'INFISICAL_UNIVERSAL_AUTH_CLIENT_ID'),
          universal_auth_client_secret=lookup('env', 'INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET')
        ) }}"

    - name: Confirm login (url only — do not print the token)
      ansible.builtin.debug:
        msg: "Logged in to {{ infisical_login.url }}"

    # 1. Create
    - name: Create the test folder
      infisical.vault.create_folder:
        login_data: "{{ infisical_login }}"
        project_id: "{{ project_id }}"
        env_slug: "{{ env_slug }}"
        path: "{{ parent_path }}"
        name: "{{ folder_name }}"
        description: "Created by test_folders.yml"
      register: created_folder

    - name: Show the created folder
      ansible.builtin.debug:
        var: created_folder.folder

    - name: Assert the folder was created
      ansible.builtin.assert:
        that:
          - created_folder.changed
          - created_folder.folder.id is defined
          - created_folder.folder.name == folder_name
        fail_msg: "create_folder did not return a folder with an id and the expected name"

    # 2. Read: list the parent path
    - name: List folders under the parent path
      infisical.vault.read_folders:
        login_data: "{{ infisical_login }}"
        project_id: "{{ project_id }}"
        env_slug: "{{ env_slug }}"
        path: "{{ parent_path }}"
      register: listed_folders

    - name: Show the listed folders
      ansible.builtin.debug:
        var: listed_folders.folders

    - name: Assert the new folder appears in the listing
      ansible.builtin.assert:
        that:
          - not listed_folders.changed
          - folder_name in (listed_folders.folders | map(attribute='name') | list)
        fail_msg: "read_folders did not list the folder just created"

    # 3. Read: get by id
    - name: Get the folder by ID
      infisical.vault.read_folders:
        login_data: "{{ infisical_login }}"
        folder_id: "{{ created_folder.folder.id }}"
      register: folder_by_id

    - name: Show the folder fetched by ID
      ansible.builtin.debug:
        var: folder_by_id.folders

    - name: Assert the by-ID read returned exactly the created folder
      ansible.builtin.assert:
        that:
          - folder_by_id.folders | length == 1
          - folder_by_id.folders[0].id == created_folder.folder.id
          - folder_by_id.folders[0].name == folder_name
        fail_msg: "read_folders with folder_id did not return the created folder"

    # 4. Read: recursive listing
    - name: List folders recursively under the parent path
      infisical.vault.read_folders:
        login_data: "{{ infisical_login }}"
        project_id: "{{ project_id }}"
        env_slug: "{{ env_slug }}"
        path: "{{ parent_path }}"
        recursive: true
      register: recursive_folders

    - name: Show the recursive listing
      ansible.builtin.debug:
        var: recursive_folders.folders

    - name: Assert the recursive listing includes the new folder
      ansible.builtin.assert:
        that:
          - folder_name in (recursive_folders.folders | map(attribute='name') | list)
        fail_msg: "recursive read_folders did not include the folder just created"

    # 5. Read: lookup plugin
    - name: Read folders via the lookup plugin
      ansible.builtin.set_fact:
        lookup_folders: "{{ lookup('infisical.vault.read_folders',
          login_data=infisical_login,
          project_id=project_id,
          env_slug=env_slug,
          path=parent_path
        ) }}"

    - name: Show the lookup result
      ansible.builtin.debug:
        var: lookup_folders

    - name: Assert the lookup found the new folder
      ansible.builtin.assert:
        that:
          - folder_name in (lookup_folders | map(attribute='name') | list)
        fail_msg: "the read_folders lookup did not return the folder just created"

    # 6. Update, using an ID resolved from the listing (update takes no names)
    - name: Rename the folder, using the ID found in the listing
      infisical.vault.update_folder:
        login_data: "{{ infisical_login }}"
        project_id: "{{ project_id }}"
        env_slug: "{{ env_slug }}"
        path: "{{ parent_path }}"
        folder_id: "{{ (listed_folders.folders | selectattr('name', 'eq', folder_name) | first).id }}"
        name: "{{ renamed_folder_name }}"
        description: "Renamed by test_folders.yml"
      register: renamed_folder

    - name: Show the renamed folder
      ansible.builtin.debug:
        var: renamed_folder.folder

    - name: Assert the rename worked
      ansible.builtin.assert:
        that:
          - renamed_folder.changed
          - renamed_folder.folder.name == renamed_folder_name
          - renamed_folder.folder.id == created_folder.folder.id
        fail_msg: "update_folder did not rename the folder"

    # 7. Update again (rename back), using the ID from the create response
    - name: Rename the folder back, using the ID from the create response
      infisical.vault.update_folder:
        login_data: "{{ infisical_login }}"
        project_id: "{{ project_id }}"
        env_slug: "{{ env_slug }}"
        path: "{{ parent_path }}"
        folder_id: "{{ created_folder.folder.id }}"
        name: "{{ folder_name }}"
      register: restored_folder

    - name: Show the restored folder
      ansible.builtin.debug:
        var: restored_folder.folder

    - name: Assert the rename back worked and the description survived
      ansible.builtin.assert:
        that:
          - restored_folder.folder.name == folder_name
          - restored_folder.folder.description == "Renamed by test_folders.yml"
        fail_msg: >-
          update_folder did not rename the folder back, or omitting description
          cleared it instead of leaving it unchanged

    # 8. Delete
    - name: Delete the folder by name
      infisical.vault.delete_folder:
        login_data: "{{ infisical_login }}"
        project_id: "{{ project_id }}"
        env_slug: "{{ env_slug }}"
        path: "{{ parent_path }}"
        folder_id_or_name: "{{ folder_name }}"
        force_delete: true
      register: deleted_folder

    - name: Show the deleted folder
      ansible.builtin.debug:
        var: deleted_folder.folder

    - name: Assert the delete reported the right folder
      ansible.builtin.assert:
        that:
          - deleted_folder.changed
          - deleted_folder.folder.id == created_folder.folder.id
        fail_msg: "delete_folder did not report the folder that was created"

    # 9. Confirm it is gone
    - name: List folders again after the delete
      infisical.vault.read_folders:
        login_data: "{{ infisical_login }}"
        project_id: "{{ project_id }}"
        env_slug: "{{ env_slug }}"
        path: "{{ parent_path }}"
      register: folders_after_delete

    - name: Show the folders after the delete
      ansible.builtin.debug:
        var: folders_after_delete.folders

    - name: Assert the folder is gone
      ansible.builtin.assert:
        that:
          - folder_name not in (folders_after_delete.folders | map(attribute='name') | list)
          - renamed_folder_name not in (folders_after_delete.folders | map(attribute='name') | list)
        fail_msg: "the test folder still exists after delete_folder"

    - name: Done
      ansible.builtin.debug:
        msg: "Folder CRUD lifecycle passed against {{ infisical_url }} ({{ env_slug }} @ {{ parent_path }})"

```